### PR TITLE
Customizable Probe and Constant

### DIFF
--- a/src/com/ra4king/circuitsim/gui/GuiUtils.java
+++ b/src/com/ra4king/circuitsim/gui/GuiUtils.java
@@ -172,6 +172,16 @@ public class GuiUtils {
 			}
 		}
 	}
+
+	public static void drawValueOneLine(GraphicsContext graphics, String string, int x, int y, int width) {
+		Bounds bounds = GuiUtils.getBounds(graphics.getFont(), string, false);
+
+		if(string.length() == 1) {
+			graphics.fillText(string, x + (width - bounds.getWidth()) * 0.5, y + bounds.getHeight() * 0.75 + 1);
+		} else {
+			graphics.fillText(string, x + 1, y + bounds.getHeight() * 0.75 + 1);
+		}
+	}
 	
 	/**
 	 * Draws a clock input (triangle symbol) facing the southern border

--- a/src/com/ra4king/circuitsim/gui/Properties.java
+++ b/src/com/ra4king/circuitsim/gui/Properties.java
@@ -272,7 +272,7 @@ public class Properties {
 	}
 
 	public enum Base {
-		BINARY, HEXADECIMAL
+		BINARY, HEXADECIMAL, DECIMAL
 	}
 	
 	static {

--- a/src/com/ra4king/circuitsim/gui/Properties.java
+++ b/src/com/ra4king/circuitsim/gui/Properties.java
@@ -265,9 +265,14 @@ public class Properties {
 	public static final Property<Integer> SELECTOR_BITS;
 	public static final Property<Direction> DIRECTION;
 	public static final Property<Boolean> SELECTOR_LOCATION;
+	public static final Property<Base> BASE;
 	
 	public enum Direction {
 		NORTH, SOUTH, EAST, WEST
+	}
+
+	public enum Base {
+		BINARY, HEXADECIMAL
 	}
 	
 	static {
@@ -304,6 +309,8 @@ public class Properties {
 		SELECTOR_BITS = new Property<>("Selector bits", new PropertyListValidator<>(selBits), 1);
 		
 		SELECTOR_LOCATION = new Property<>("Selector location", LOCATION_VALIDATOR, false);
+
+		BASE = new Property<>("Base", new PropertyListValidator<>(Base.values()), Base.BINARY);
 	}
 	
 	public static class Property<T> {

--- a/src/com/ra4king/circuitsim/gui/peers/wiring/ConstantPeer.java
+++ b/src/com/ra4king/circuitsim/gui/peers/wiring/ConstantPeer.java
@@ -40,16 +40,35 @@ public class ConstantPeer extends ComponentPeer<Constant> {
 		properties.ensureProperty(Properties.LABEL_LOCATION);
 		properties.ensureProperty(Properties.DIRECTION);
 		properties.ensureProperty(Properties.BITSIZE);
+		properties.ensureProperty(Properties.BASE);
 		properties.ensureProperty(VALUE);
 		properties.mergeIfExists(props);
 		
 		Constant constant = new Constant(properties.getValue(Properties.LABEL),
 		                                 properties.getValue(Properties.BITSIZE),
 		                                 properties.getValue(VALUE));
-		setWidth(Math.max(2, Math.min(8, constant.getBitSize())));
-		setHeight((int)Math.round((1 + (constant.getBitSize() - 1) / 8) * 1.5));
+
+		int bitSize = constant.getBitSize();
+		switch(properties.getValue(Properties.BASE)) {
+			case BINARY:
+				setWidth(Math.max(2, Math.min(8, bitSize)));
+				setHeight((int)Math.round((1 + (bitSize - 1) / 8) * 1.5));
+				break;
+			case HEXADECIMAL:
+				setWidth(Math.max(2, 1 + (bitSize - 1) / 4));
+				setHeight(2);
+				break;
+			case DECIMAL:
+				// 3.322 ~ log_2(10)
+				int width = Math.max(2, (int) Math.ceil(bitSize / 3.322));
+				width += bitSize == 32 ? 1 : 0;
+				setWidth(width);
+				int height = width > 8 ? 3 : 2;
+				setHeight(height);
+				break;
+		}
 		
-		value = WireValue.of(constant.getValue(), constant.getBitSize());
+		value = WireValue.of(constant.getValue(), bitSize);
 		
 		List<PortConnection> connections = new ArrayList<>();
 		switch(properties.getValue(Properties.DIRECTION)) {
@@ -80,6 +99,19 @@ public class ConstantPeer extends ComponentPeer<Constant> {
 		
 		graphics.fillRoundRect(getScreenX(), getScreenY(), getScreenWidth(), getScreenHeight(), 10, 10);
 		graphics.strokeRoundRect(getScreenX(), getScreenY(), getScreenWidth(), getScreenHeight(), 10, 10);
+
+		String valStr = "";
+		switch(getProperties().getValue(Properties.BASE)) {
+			case BINARY:
+				valStr = value.toString();
+				break;
+			case HEXADECIMAL:
+				valStr = value.toHexString();
+				break;
+			case DECIMAL:
+				valStr = value.toDecString();
+				break;
+		}
 		
 		if(value.getBitSize() > 1) {
 			graphics.setFill(Color.BLACK);
@@ -87,6 +119,6 @@ public class ConstantPeer extends ComponentPeer<Constant> {
 			GuiUtils.setBitColor(graphics, value.getBit(0));
 		}
 		
-		GuiUtils.drawValue(graphics, value.toString(), getScreenX(), getScreenY(), getScreenWidth());
+		GuiUtils.drawValue(graphics, valStr, getScreenX(), getScreenY(), getScreenWidth());
 	}
 }

--- a/src/com/ra4king/circuitsim/gui/peers/wiring/ConstantPeer.java
+++ b/src/com/ra4king/circuitsim/gui/peers/wiring/ConstantPeer.java
@@ -63,8 +63,7 @@ public class ConstantPeer extends ComponentPeer<Constant> {
 				int width = Math.max(2, (int) Math.ceil(bitSize / 3.322));
 				width += bitSize == 32 ? 1 : 0;
 				setWidth(width);
-				int height = width > 8 ? 3 : 2;
-				setHeight(height);
+				setHeight(2);
 				break;
 		}
 		
@@ -118,7 +117,11 @@ public class ConstantPeer extends ComponentPeer<Constant> {
 		} else {
 			GuiUtils.setBitColor(graphics, value.getBit(0));
 		}
-		
-		GuiUtils.drawValue(graphics, valStr, getScreenX(), getScreenY(), getScreenWidth());
+
+		if (getProperties().getValue(Properties.BASE) == Properties.Base.DECIMAL) {
+			GuiUtils.drawValueOneLine(graphics, valStr, getScreenX(), getScreenY(), getScreenWidth());
+		} else {
+			GuiUtils.drawValue(graphics, valStr, getScreenX(), getScreenY(), getScreenWidth());
+		}
 	}
 }

--- a/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
+++ b/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
@@ -64,7 +64,8 @@ public class Probe extends ComponentPeer<Component> {
 				int width = Math.max(2, (int) Math.ceil(bitSize / 3.322));
 				width += bitSize == 32 ? 1 : 0;
 				setWidth(width);
-				setHeight(2);
+				int height = width > 8 ? 3 : 2;
+				setHeight(height);
 				break;
 		}
 		

--- a/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
+++ b/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
@@ -64,8 +64,7 @@ public class Probe extends ComponentPeer<Component> {
 				int width = Math.max(2, (int) Math.ceil(bitSize / 3.322));
 				width += bitSize == 32 ? 1 : 0;
 				setWidth(width);
-				int height = width > 8 ? 3 : 2;
-				setHeight(height);
+				setHeight(2);
 				break;
 		}
 		
@@ -121,6 +120,10 @@ public class Probe extends ComponentPeer<Component> {
 		graphics.strokeRoundRect(getScreenX(), getScreenY(), getScreenWidth(), getScreenHeight(), 20, 20);
 		
 		graphics.setFill(Color.BLACK);
-		GuiUtils.drawValue(graphics, valStr, getScreenX(), getScreenY(), getScreenWidth());
+		if (getProperties().getValue(Properties.BASE) == Properties.Base.DECIMAL) {
+			GuiUtils.drawValueOneLine(graphics, valStr, getScreenX(), getScreenY(), getScreenWidth());
+		} else {
+			GuiUtils.drawValue(graphics, valStr, getScreenX(), getScreenY(), getScreenWidth());
+		}
 	}
 }

--- a/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
+++ b/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
@@ -59,6 +59,11 @@ public class Probe extends ComponentPeer<Component> {
 				setWidth(Math.max(2, (int) (bitSize / 4)));
 				setHeight(2);
 				break;
+			case DECIMAL:
+				// 3.322 ~ log_2(10)
+				setWidth(Math.max(2, (int) Math.ceil(bizeSize / 3.322)));
+				setHeight(2);
+				break;
 		}
 		
 		List<PortConnection> connections = new ArrayList<>();
@@ -95,6 +100,9 @@ public class Probe extends ComponentPeer<Component> {
 				break;
 			case HEXADECIMAL:
 				valStr = value.toHexString();
+				break;
+			case DECIMAL:
+				valStr = String.valueOf(value.getValue());
 				break;
 		}
 

--- a/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
+++ b/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
@@ -9,6 +9,7 @@ import com.ra4king.circuitsim.gui.Connection.PortConnection;
 import com.ra4king.circuitsim.gui.GuiUtils;
 import com.ra4king.circuitsim.gui.Properties;
 import com.ra4king.circuitsim.gui.Properties.Direction;
+import com.ra4king.Circuitsim.gui.Properties.Base;
 import com.ra4king.circuitsim.gui.Properties.Property;
 import com.ra4king.circuitsim.simulator.CircuitState;
 import com.ra4king.circuitsim.simulator.Component;
@@ -38,6 +39,7 @@ public class Probe extends ComponentPeer<Component> {
 		properties.ensureProperty(Properties.LABEL_LOCATION);
 		properties.ensureProperty(Properties.DIRECTION);
 		properties.ensureProperty(Properties.BITSIZE);
+		properties.ensureProperty(Properties.BASE);
 		properties.mergeIfExists(props);
 		
 		int bitSize = properties.getValue(Properties.BITSIZE);
@@ -47,9 +49,17 @@ public class Probe extends ComponentPeer<Component> {
 			@Override
 			public void valueChanged(CircuitState state, WireValue value, int portIndex) {}
 		};
-		
-		setWidth(Math.max(2, Math.min(8, bitSize)));
-		setHeight((int)Math.round((1 + (bitSize - 1) / 8) * 1.5));
+
+		switch(properties.getValue(Properties.BASE)) {
+			case BINARY:
+				setWidth(Math.max(2, Math.min(8, bitSize)));
+				setHeight((int)Math.round((1 + (bitSize - 1) / 8) * 1.5));
+				break;
+			case HEXADECIMAL:
+				setWidth(Math.max(2, (int) (bitSize / 4)));
+				setHeight(2);
+				break;
+		}
 		
 		List<PortConnection> connections = new ArrayList<>();
 		switch(properties.getValue(Properties.DIRECTION)) {
@@ -76,7 +86,18 @@ public class Probe extends ComponentPeer<Component> {
 		
 		graphics.setFont(GuiUtils.getFont(16));
 		Port port = getComponent().getPort(0);
+
 		WireValue value = circuitState.getLastReceived(port);
+		String valStr;
+		switch(getProperties().getValue(Properties.BASE)) {
+			case BINARY:
+				valStr = value.toString();
+				break;
+			case HEXADECIMAL:
+				valStr = value.toHexString();
+				break;
+		}
+
 		if(circuitState.isShortCircuited(port.getLink())) {
 			graphics.setFill(Color.RED);
 		} else {
@@ -89,6 +110,6 @@ public class Probe extends ComponentPeer<Component> {
 		graphics.strokeRoundRect(getScreenX(), getScreenY(), getScreenWidth(), getScreenHeight(), 20, 20);
 		
 		graphics.setFill(Color.BLACK);
-		GuiUtils.drawValue(graphics, value.toString(), getScreenX(), getScreenY(), getScreenWidth());
+		GuiUtils.drawValue(graphics, valStr, getScreenX(), getScreenY(), getScreenWidth());
 	}
 }

--- a/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
+++ b/src/com/ra4king/circuitsim/gui/peers/wiring/Probe.java
@@ -9,7 +9,7 @@ import com.ra4king.circuitsim.gui.Connection.PortConnection;
 import com.ra4king.circuitsim.gui.GuiUtils;
 import com.ra4king.circuitsim.gui.Properties;
 import com.ra4king.circuitsim.gui.Properties.Direction;
-import com.ra4king.Circuitsim.gui.Properties.Base;
+import com.ra4king.circuitsim.gui.Properties.Base;
 import com.ra4king.circuitsim.gui.Properties.Property;
 import com.ra4king.circuitsim.simulator.CircuitState;
 import com.ra4king.circuitsim.simulator.Component;
@@ -56,12 +56,14 @@ public class Probe extends ComponentPeer<Component> {
 				setHeight((int)Math.round((1 + (bitSize - 1) / 8) * 1.5));
 				break;
 			case HEXADECIMAL:
-				setWidth(Math.max(2, (int) (bitSize / 4)));
+				setWidth(Math.max(2, 1 + (bitSize - 1) / 4));
 				setHeight(2);
 				break;
 			case DECIMAL:
 				// 3.322 ~ log_2(10)
-				setWidth(Math.max(2, (int) Math.ceil(bizeSize / 3.322)));
+				int width = Math.max(2, (int) Math.ceil(bitSize / 3.322));
+				width += bitSize == 32 ? 1 : 0;
+				setWidth(width);
 				setHeight(2);
 				break;
 		}
@@ -93,7 +95,7 @@ public class Probe extends ComponentPeer<Component> {
 		Port port = getComponent().getPort(0);
 
 		WireValue value = circuitState.getLastReceived(port);
-		String valStr;
+		String valStr = "";
 		switch(getProperties().getValue(Properties.BASE)) {
 			case BINARY:
 				valStr = value.toString();
@@ -102,7 +104,7 @@ public class Probe extends ComponentPeer<Component> {
 				valStr = value.toHexString();
 				break;
 			case DECIMAL:
-				valStr = String.valueOf(value.getValue());
+				valStr = value.toDecString();
 				break;
 		}
 

--- a/src/com/ra4king/circuitsim/simulator/WireValue.java
+++ b/src/com/ra4king/circuitsim/simulator/WireValue.java
@@ -168,6 +168,26 @@ public class WireValue {
 		return value;
 	}
 
+	/**
+	 * Converts the value held on this wire to a decimal string.
+	 *
+	 * @return a decimal string if all bits are defined, otherwise
+	 *         getBitSize() 'x's
+	 */
+	public String toDecString() {
+		String value;
+		int decDigits = (int) Math.ceil(getBitSize() / 3.322);
+		if(isValidValue()) {
+			value = String.format("%0" + decDigits + "d", getValue());
+		} else {
+			value = "";
+			for(int i = 0; i < decDigits; i++) {
+				value += "x";
+			}
+		}
+		return value;
+	}
+
 	@Override
 	public boolean equals(Object other) {
 		if(other instanceof WireValue) {


### PR DESCRIPTION
I've added the ability for users to change the number system of the probe component. Currently, users can only see the value of wires and buses as binary numbers. This PR adds the ability to see numbers in hexadecimal form and decimal form. This was implemented using a new BASE property, which was also applied to the constant component. 