### PR TITLE
Reduce confusion by making Adders, Subtractors, and Multipliers emit floating until C-IN is connected as well

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Adder.java
+++ b/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Adder.java
@@ -34,7 +34,7 @@ public class Adder extends Component {
 		
 		if (state.getLastReceived(getPort(PORT_A)).isValidValue() &&
 		    state.getLastReceived(getPort(PORT_B)).isValidValue() &&
-			state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
+		state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
 			WireValue a = state.getLastReceived(getPort(PORT_A));
 			WireValue b = state.getLastReceived(getPort(PORT_B));
 			WireValue c = state.getLastReceived(getPort(PORT_CARRY_IN));

--- a/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Adder.java
+++ b/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Adder.java
@@ -34,7 +34,7 @@ public class Adder extends Component {
 		
 		if (state.getLastReceived(getPort(PORT_A)).isValidValue() &&
 		    state.getLastReceived(getPort(PORT_B)).isValidValue() &&
-		state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
+		    state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
 			WireValue a = state.getLastReceived(getPort(PORT_A));
 			WireValue b = state.getLastReceived(getPort(PORT_B));
 			WireValue c = state.getLastReceived(getPort(PORT_CARRY_IN));

--- a/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Adder.java
+++ b/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Adder.java
@@ -33,7 +33,8 @@ public class Adder extends Component {
 		}
 		
 		if (state.getLastReceived(getPort(PORT_A)).isValidValue() &&
-		    state.getLastReceived(getPort(PORT_B)).isValidValue()) {
+		    state.getLastReceived(getPort(PORT_B)).isValidValue() &&
+			state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
 			WireValue a = state.getLastReceived(getPort(PORT_A));
 			WireValue b = state.getLastReceived(getPort(PORT_B));
 			WireValue c = state.getLastReceived(getPort(PORT_CARRY_IN));
@@ -55,7 +56,7 @@ public class Adder extends Component {
 			state.pushValue(getPort(PORT_CARRY_OUT), new WireValue(1, carry));
 		} else {
 			state.pushValue(getPort(PORT_OUT), new WireValue(bitSize));
-			state.pushValue(getPort(PORT_CARRY_OUT), new WireValue(1));
+			state.pushValue(getPort(PORT_CARRY_OUT), new WireValue(State.Z));
 		}
 	}
 }

--- a/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Multiplier.java
+++ b/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Multiplier.java
@@ -34,7 +34,7 @@ public class Multiplier extends Component {
 		
 		if (state.getLastReceived(getPort(PORT_A)).isValidValue() &&
 		    state.getLastReceived(getPort(PORT_B)).isValidValue() &&
-			state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
+		    state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
 			long a = state.getLastReceived(getPort(PORT_A)).getValue() & 0xFFFFFFFFL;
 			long b = state.getLastReceived(getPort(PORT_B)).getValue() & 0xFFFFFFFFL;
 			WireValue carry = state.getLastReceived(getPort(PORT_CARRY_IN));

--- a/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Multiplier.java
+++ b/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Multiplier.java
@@ -33,7 +33,8 @@ public class Multiplier extends Component {
 		}
 		
 		if (state.getLastReceived(getPort(PORT_A)).isValidValue() &&
-		    state.getLastReceived(getPort(PORT_B)).isValidValue()) {
+		    state.getLastReceived(getPort(PORT_B)).isValidValue() &&
+			state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
 			long a = state.getLastReceived(getPort(PORT_A)).getValue() & 0xFFFFFFFFL;
 			long b = state.getLastReceived(getPort(PORT_B)).getValue() & 0xFFFFFFFFL;
 			WireValue carry = state.getLastReceived(getPort(PORT_CARRY_IN));

--- a/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Subtractor.java
+++ b/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Subtractor.java
@@ -33,7 +33,8 @@ public class Subtractor extends Component {
 		}
 		
 		if (state.getLastReceived(getPort(PORT_A)).isValidValue() &&
-		    state.getLastReceived(getPort(PORT_B)).isValidValue()) {
+		    state.getLastReceived(getPort(PORT_B)).isValidValue() &&
+			state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
 			int a = state.getLastReceived(getPort(PORT_A)).getValue();
 			int b = state.getLastReceived(getPort(PORT_B)).getValue();
 			WireValue carry = state.getLastReceived(getPort(PORT_CARRY_IN));
@@ -44,7 +45,7 @@ public class Subtractor extends Component {
 			state.pushValue(getPort(PORT_CARRY_OUT), WireValue.of(a - b - c < 0 ? 1 : 0, 1));
 		} else {
 			state.pushValue(getPort(PORT_OUT), new WireValue(bitSize));
-			state.pushValue(getPort(PORT_CARRY_OUT), new WireValue(1));
+			state.pushValue(getPort(PORT_CARRY_OUT), new WireValue(State.Z));
 		}
 	}
 }

--- a/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Subtractor.java
+++ b/src/main/java/com/ra4king/circuitsim/simulator/components/arithmetic/Subtractor.java
@@ -34,7 +34,7 @@ public class Subtractor extends Component {
 		
 		if (state.getLastReceived(getPort(PORT_A)).isValidValue() &&
 		    state.getLastReceived(getPort(PORT_B)).isValidValue() &&
-			state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
+		    state.getLastReceived(getPort(PORT_CARRY_IN)).isValidValue()) {
 			int a = state.getLastReceived(getPort(PORT_A)).getValue();
 			int b = state.getLastReceived(getPort(PORT_B)).getValue();
 			WireValue carry = state.getLastReceived(getPort(PORT_CARRY_IN));


### PR DESCRIPTION
Original components would treat a floating CIN input as a zero. This causes confusion as it is not how these components should work. Students making an adder themselves would proceed to get into a habit of not connecting a CIN as a result and their adders would not work.