### PR TITLE
Add some quality-of-life changes regarding text/selection shortcuts

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -676,7 +676,7 @@ public class CircuitManager {
 	}
 	
 	public void keyTyped(KeyEvent e) {
-		if (selectedElements.size() == 1) {
+		if (selectedElements.size() == 1 && !e.isShortcutDown()) {
 			GuiElement element = selectedElements.iterator().next();
 			element.keyTyped(this, circuitBoard.getCurrentState(), e.getCharacter());
 			setNeedsRepaint();

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -898,7 +898,14 @@ public class CircuitManager {
 							                             lastMousePosition.getY() - selectedElement.getScreenY());
 						} else if (isCtrlDown) {
 							Set<GuiElement> elements = new HashSet<>(getSelectedElements());
-							elements.add(selectedElement);
+
+							// toggle selected element
+							if (elements.contains(selectedElement)) {
+								elements.remove(selectedElement);
+							} else {
+								elements.add(selectedElement);
+							}
+
 							setSelectedElements(elements);
 						} else if (!getSelectedElements().contains(selectedElement)) {
 							setSelectedElements(Collections.singleton(selectedElement));
@@ -977,14 +984,19 @@ public class CircuitManager {
 				break;
 			
 			case CONNECTION_SELECTED: {
-				Set<Connection>
-					connections =
-					circuitBoard.getConnections(startConnection.getX(), startConnection.getY());
+				Set<GuiElement> selectedEls = new HashSet<>(isCtrlDown ? getSelectedElements() : Set.of());
+
+				for (Connection c : circuitBoard.getConnections(startConnection.getX(), startConnection.getY())) {
+					GuiElement el = c.getParent();
+					// toggle wire
+					if (selectedEls.contains(el)) {
+						selectedEls.remove(el);
+					} else {
+						selectedEls.add(el);
+					}
+				}
 				
-				setSelectedElements(Stream
-					                    .concat(isCtrlDown ? getSelectedElements().stream() : Stream.empty(),
-					                            connections.stream().map(Connection::getParent))
-					                    .collect(Collectors.toSet()));
+				setSelectedElements(selectedEls);
 				currentState = SelectingState.IDLE;
 				break;
 			}

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -625,6 +625,10 @@ public class CircuitManager {
 		
 		setNeedsRepaint();
 		
+		if (e.isShortcutDown()) {
+			isCtrlDown = true;
+		}
+
 		switch (e.getCode()) {
 			case RIGHT: {
 				e.consume();
@@ -646,9 +650,6 @@ public class CircuitManager {
 				handleArrowPressed(Direction.SOUTH);
 				break;
 			}
-			case CONTROL:
-				isCtrlDown = true;
-				break;
 			case SHIFT:
 				if (currentState != SelectingState.CONNECTION_SELECTED &&
 				    currentState != SelectingState.CONNECTION_DRAGGED) {
@@ -683,15 +684,15 @@ public class CircuitManager {
 	}
 	
 	public void keyReleased(KeyEvent e) {
-		switch (e.getCode()) {
-			case CONTROL -> {
+		if (e.getCode().isModifierKey()) {
+			if (!e.isShortcutDown()) {
 				isCtrlDown = false;
 				setNeedsRepaint();
 			}
-			case SHIFT -> {
+			if (!e.isShiftDown()) {
 				simulatorWindow.setClickMode(false);
-				isShiftDown = false;
-				setNeedsRepaint();
+					isShiftDown = false;
+					setNeedsRepaint();
 			}
 		}
 		

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -2286,21 +2286,36 @@ public class CircuitSim extends Application {
 		
 		MenuItem copy = new MenuItem("Copy");
 		copy.setAccelerator(new KeyCodeCombination(KeyCode.C, KeyCombination.SHORTCUT_DOWN));
-		copy.setOnAction(event -> copySelectedComponents());
+		copy.setOnAction(event -> {
+			CircuitManager manager = getCurrentCircuit();
+			if (manager != null && manager.getCanvas().isFocused()) {
+				copySelectedComponents();
+			}
+		});
 		
 		MenuItem cut = new MenuItem("Cut");
 		cut.setAccelerator(new KeyCodeCombination(KeyCode.X, KeyCombination.SHORTCUT_DOWN));
-		cut.setOnAction(event -> cutSelectedComponents());
+		cut.setOnAction(event -> {
+			CircuitManager manager = getCurrentCircuit();
+			if (manager != null && manager.getCanvas().isFocused()) {
+				cutSelectedComponents();
+			}
+		});
 		
 		MenuItem paste = new MenuItem("Paste");
 		paste.setAccelerator(new KeyCodeCombination(KeyCode.V, KeyCombination.SHORTCUT_DOWN));
-		paste.setOnAction(event -> pasteFromClipboard());
+		paste.setOnAction(event -> {
+			CircuitManager manager = getCurrentCircuit();
+			if (manager != null && manager.getCanvas().isFocused()) {
+				pasteFromClipboard();
+			}
+		});
 		
 		MenuItem selectAll = new MenuItem("Select All");
 		selectAll.setAccelerator(new KeyCodeCombination(KeyCode.A, KeyCombination.SHORTCUT_DOWN));
 		selectAll.setOnAction(event -> {
 			CircuitManager manager = getCurrentCircuit();
-			if (manager != null) {
+			if (manager != null && manager.getCanvas().isFocused()) {
 				manager.setSelectedElements(Stream
 					                            .concat(manager.getCircuitBoard().getComponents().stream(),
 					                                    manager

--- a/src/main/java/com/ra4king/circuitsim/gui/peers/misc/Text.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/peers/misc/Text.java
@@ -87,29 +87,43 @@ public class Text extends ComponentPeer<Component> {
 		entered = false;
 	}
 	
+	private boolean backspaceDown;
 	@Override
 	public boolean keyPressed(CircuitManager manager, CircuitState state, KeyCode keyCode, String text) {
+		if (keyCode == KeyCode.BACK_SPACE) {
+			backspaceDown = true;
+		}
 		return keyCode == KeyCode.BACK_SPACE && !this.text.isEmpty();
 	}
 	
 	@Override
+	public void keyReleased(CircuitManager manager, CircuitState state, KeyCode keyCode, String text) {
+		if (keyCode == KeyCode.BACK_SPACE) {
+			backspaceDown = false;
+		}
+		super.keyReleased(manager, state, keyCode, text);
+	}
+
+	@Override
 	public void keyTyped(CircuitManager manager, CircuitState state, String character) {
-		char c = character.charAt(0);
-		
-		if (c == 8) { // backspace
-			if (!text.isEmpty()) {
+		if (character.isEmpty()) {
+			if (backspaceDown && !text.isEmpty()) {
 				String s = text.substring(0, text.length() - 1);
 				setText(s);
 				getProperties().setValue(TEXT, s);
 			}
-		} else if (c == 10 || c == 13 || c >= 32 && c <= 126) { // line feed, carriage return, or visible ASCII char 
-			if (c == 13) {
-				c = 10; // convert \r to \n
-			}
+		} else {
+			char c = character.charAt(0);
 			
-			String s = text + c;
-			setText(s);
-			getProperties().setValue(TEXT, s);
+			if (c == 10 || c == 13 || c >= 32 && c <= 126) { // line feed, carriage return, or visible ASCII char 
+				if (c == 13) {
+					c = 10; // convert \r to \n
+				}
+				
+				String s = text + c;
+				setText(s);
+				getProperties().setValue(TEXT, s);
+			}
 		}
 	}
 	


### PR DESCRIPTION
## Text Updates
- Typical text-editing shortcuts (Ctrl + A, Ctrl + C, Ctrl + V, Ctrl + X, Ctrl + Z) can now be used in text inputs without activating the canvas shortcuts (e.g., selecting all components).
- Backspace should now work properly on the text component

## Selection Updates
- Ctrl-clicking a component now toggle-selects components
- (macOS) Command-clicking should allow you to select components (which would be done by ctrl-clicking on Windows).
    - Note that you can technically already ctrl-click on macOS, but it also opens a context menu, which is probably unintended