### PR TITLE
Remove circuit from simulator when tab closed

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -631,6 +631,7 @@ public class CircuitSim extends Application {
 			
 			Pair<ComponentLauncherInfo, CircuitManager> removed = circuitManagers.remove(tab.getText());
 			circuitModified(removed.getValue().getCircuit(), null, false);
+			removed.getValue().destroy();
 			
 			editHistory.addAction(EditAction.DELETE_CIRCUIT, manager, tab, idx);
 			


### PR DESCRIPTION
Deleting a subcircuit in the GUI does not actually remove it from the simulator. This results in ghost exceptions from short circuits that occurred in circuits that should have been deleted.

Still reviewing consequences for undo/redo