### PR TITLE
Improve Canvas rendering & movement gestures

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitBoard.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitBoard.java
@@ -482,7 +482,7 @@ public class CircuitBoard {
 					
 					lastException = null;
 					
-					circuitManager.setNeedsRepaint();
+					circuitManager.getSimulatorWindow().setNeedsRepaint();
 				}
 				
 				latch.countDown();

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -93,8 +93,6 @@ public class CircuitManager {
 	private final ScrollPane canvasScrollPane;
 	private final BooleanProperty showGrid;
 	private final CircuitBoard circuitBoard;
-
-	private ContextMenu menu;
 	
 	/**
 	 * The position of the last mouse interaction on the Canvas
@@ -161,7 +159,7 @@ public class CircuitManager {
 		circuitBoard = new CircuitBoard(name, this, simulator, simulatorWindow.getEditHistory());
 		
 		getCanvas().setOnContextMenuRequested(event -> {
-			menu = new ContextMenu();
+			ContextMenu menu = new ContextMenu();
 			
 			MenuItem copy = new MenuItem("Copy");
 			copy.setOnAction(event1 -> simulatorWindow.copySelectedComponents());
@@ -211,7 +209,7 @@ public class CircuitManager {
 			}
 			
 			if (menu.getItems().size() > 0) {
-				menu.show(getCanvas(), event.getScreenX(), event.getScreenY());
+				menu.show(getCanvas().getScene().getWindow(), event.getScreenX(), event.getScreenY());
 			}
 		});
 	}
@@ -939,10 +937,6 @@ public class CircuitManager {
 	}
 
 	public void mousePressed(MouseEvent e) {
-		if (menu != null) {
-			menu.hide();
-		}
-		
 		if (e.getButton() != MouseButton.PRIMARY) {
 			switch (currentState) {
 				case PLACING_COMPONENT, CONNECTION_SELECTED, CONNECTION_DRAGGED -> reset();

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -665,6 +665,8 @@ public class CircuitManager {
 					}
 					break;
 				}
+				default:
+					break;
 			}
 		} finally {
 			graphics.restore();
@@ -944,6 +946,7 @@ public class CircuitManager {
 		if (e.getButton() != MouseButton.PRIMARY) {
 			switch (currentState) {
 				case PLACING_COMPONENT, CONNECTION_SELECTED, CONNECTION_DRAGGED -> reset();
+				default -> {}
 			}
 			
 			return;

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -235,34 +235,22 @@ public class CircuitManager {
 	}
 	
 	/**
-	 * @return the maximum bounds (in the circuit coordinate system) for the size of the board.
+	 * @return the bounds for the circuit board (in the circuit coordinate system).
 	 */
-	public Bounds getMaxCircuitBounds() {
-		int maxX = Stream
-		.concat(this.getSelectedElements().stream(),
-				Stream.concat(this.getCircuitBoard().getComponents().stream(),
-							  this
-								  .getCircuitBoard()
-								  .getLinks()
-								  .stream()
-								  .flatMap(links -> links.getWires().stream())))
-		.mapToInt(componentPeer -> componentPeer.getX() + componentPeer.getWidth())
-		.max()
-		.orElse(0) + 5;
-	
-	int maxY = Stream
-		.concat(this.getSelectedElements().stream(),
-				Stream.concat(this.getCircuitBoard().getComponents().stream(),
-							  this
-								  .getCircuitBoard()
-								  .getLinks()
-								  .stream()
-								  .flatMap(links -> links.getWires().stream())))
-		.mapToInt(componentPeer -> componentPeer.getY() + componentPeer.getHeight())
-		.max()
-		.orElse(0) + 5;
+	public Bounds getCircuitBounds() {
+		Set<GuiElement> elements = new HashSet<>();
+		elements.addAll(this.getSelectedElements());
+		elements.addAll(this.getCircuitBoard().getComponents());
+		for (LinkWires links : this.getCircuitBoard().getLinks()) {
+			elements.addAll(links.getWires());
+		}
 
-		return new BoundingBox(0, 0, maxX, maxY);
+		int minX = elements.stream().mapToInt(el -> el.getX()).min().orElse(5) - 5;
+		int minY = elements.stream().mapToInt(el -> el.getY()).min().orElse(5) - 5;
+		int maxX = elements.stream().mapToInt(el -> el.getX() + el.getWidth()).max().orElse(0) + 5;
+		int maxY = elements.stream().mapToInt(el -> el.getY() + el.getHeight()).max().orElse(0) + 5;
+
+		return new BoundingBox(minX, minY, maxX - minX, maxY - minY);
 	}
 
 	public Circuit getCircuit() {

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -412,22 +412,20 @@ public class CircuitManager {
 	}
 	@Deprecated
 	public void paint() {
-		paint(getCanvas().getGraphicsContext2D());
+		paint(getCanvas());
 	}
-	public void paint(GraphicsContext graphics) {
-		if (graphics == null) return;
-		
+	public void paint(Canvas canvas) {
+		if (canvas == null) return;
+		GraphicsContext graphics = canvas.getGraphicsContext2D();
 		graphics.save();
 		try {
 			graphics.setFont(GuiUtils.getFont(13));
 			graphics.setFontSmoothingType(FontSmoothingType.LCD);
 			
 			// Set a background.
-			double canvasWidth = graphics.getCanvas().getWidth();
-			double canvasHeight = graphics.getCanvas().getHeight();
 			boolean drawGrid = showGrid.getValue();
 			graphics.setFill(drawGrid ? Color.DARKGRAY : Color.WHITE);
-			graphics.fillRect(0, 0, canvasWidth, canvasHeight);
+			graphics.fillRect(0, 0, canvas.getWidth(), canvas.getHeight());
 			
 			// Perform graphics transform.
 			//
@@ -440,7 +438,7 @@ public class CircuitManager {
 			// Draw the light background and grid starting at canvas (0, 0) and moving onwards.
 			graphics.setFill(drawGrid ? Color.LIGHTGRAY : Color.WHITE);
 			if (drawGrid) {
-				Point2D canvasEnd = pixelToCanvasCoord(canvasWidth, canvasHeight);
+				Point2D canvasEnd = pixelToCanvasCoord(canvas.getWidth(), canvas.getHeight());
 				graphics.fillRect(0, 0, canvasEnd.getX(), canvasEnd.getY());
 				graphics.setFill(Color.BLACK);
 				for (int i = 0; i < canvasEnd.getX(); i += GuiUtils.BLOCK_SIZE) {

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -29,7 +29,6 @@ import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
-import javafx.scene.control.ScrollPane;
 import javafx.scene.input.ContextMenuEvent;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
@@ -93,8 +92,6 @@ public class CircuitManager {
 	private SelectingState currentState = SelectingState.IDLE;
 	
 	private final CircuitSim simulatorWindow;
-	@Deprecated
-	private final ScrollPane canvasScrollPane;
 	private final BooleanProperty showGrid;
 	private final CircuitBoard circuitBoard;
 	
@@ -154,9 +151,8 @@ public class CircuitManager {
 	private long lastExceptionTime;
 	private static final long SHOW_ERROR_DURATION = 3000;
 	
-	CircuitManager(String name, CircuitSim simulatorWindow, ScrollPane canvasScrollPane, Simulator simulator, BooleanProperty showGrid) {
+	CircuitManager(String name, CircuitSim simulatorWindow, Simulator simulator, BooleanProperty showGrid) {
 		this.simulatorWindow = simulatorWindow;
-		this.canvasScrollPane = canvasScrollPane;
 		this.showGrid = showGrid;
 		circuitBoard = new CircuitBoard(name, this, simulator, simulatorWindow.getEditHistory());
 	}
@@ -214,16 +210,6 @@ public class CircuitManager {
 	
 	public CircuitSim getSimulatorWindow() {
 		return simulatorWindow;
-	}
-	
-	@Deprecated
-	public ScrollPane getCanvasScrollPane() {
-		return canvasScrollPane;
-	}
-	
-	@Deprecated
-	public Canvas getCanvas() {
-		return (Canvas)canvasScrollPane.getContent();
 	}
 	
 	/**
@@ -432,10 +418,6 @@ public class CircuitManager {
 		setTranslate(translateOrigin.subtract(factor * x, factor * y));
 	}
 
-	@Deprecated
-	public void paint() {
-		paint(getCanvas());
-	}
 	public void paint(Canvas canvas) {
 		if (canvas == null) return;
 		GraphicsContext graphics = canvas.getGraphicsContext2D();

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -410,6 +410,28 @@ public class CircuitManager {
 		double y = Math.min(0, newOrigin.getY());
 		translateOrigin = new Point2D(x, y);
 	}
+	/**
+	 * Zooms in at a given point (x, y).
+	 * 
+	 * This depends on the scale before zooming in and new scale after zooming in.
+	 * (This also applies to zooming out).
+	 * 
+	 * @param x Pixel X
+	 * @param y Pixel Y
+	 * @param oldScale the old zoom scale value
+	 * @param newScale the new zoom scale value
+	 */
+	public void zoomInOnPoint(double x, double y, double oldScale, double newScale) {
+		// Let (tx, ty) = translateOrigin.
+		// Pixel (x, y) must be at the same canvas coordinate before and after zooming, 
+		// so we must meet the constraint (x / oldScale - tx = x / newScale - tx').
+		// When you solve this constraint, you get: (tx' = tx - factor * x),
+		// where factor is the value below.
+
+		double factor = (newScale - oldScale) / (newScale * oldScale);
+		setTranslate(translateOrigin.subtract(factor * x, factor * y));
+	}
+
 	@Deprecated
 	public void paint() {
 		paint(getCanvas());

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -154,8 +154,6 @@ public class CircuitManager {
 	private long lastExceptionTime;
 	private static final long SHOW_ERROR_DURATION = 3000;
 	
-	private boolean needsRepaint;
-	
 	CircuitManager(String name, CircuitSim simulatorWindow, ScrollPane canvasScrollPane, Simulator simulator, BooleanProperty showGrid) {
 		this.simulatorWindow = simulatorWindow;
 		this.canvasScrollPane = canvasScrollPane;
@@ -207,7 +205,7 @@ public class CircuitManager {
 		endConnection = null;
 		inspectLinkWires = null;
 		
-		setNeedsRepaint();
+		simulatorWindow.setNeedsRepaint();
 	}
 	
 	public void destroy() {
@@ -292,16 +290,6 @@ public class CircuitManager {
 		selectedElements.clear();
 		selectedElements.addAll(elements);
 		updateSelectedProperties();
-	}
-	
-	@Deprecated
-	boolean needsRepaint() {
-		return needsRepaint;
-	}
-	
-	@Deprecated
-	void setNeedsRepaint() {
-		needsRepaint = true;
 	}
 	
 	private Properties getCommonSelectedProperties() {
@@ -396,7 +384,7 @@ public class CircuitManager {
 		isDraggedHorizontally = false;
 		startConnection = null;
 		endConnection = null;
-		setNeedsRepaint();
+		simulatorWindow.setNeedsRepaint();
 	}
 	
 	/**
@@ -428,7 +416,6 @@ public class CircuitManager {
 	}
 	public void paint(GraphicsContext graphics) {
 		if (graphics == null) return;
-		needsRepaint = false;
 		
 		graphics.save();
 		try {
@@ -703,14 +690,14 @@ public class CircuitManager {
 			lastPressedConsumed =
 				lastPressed.keyPressed(this, circuitBoard.getCurrentState(), e.getCode(), e.getText());
 			lastPressedKeyCode = e.getCode();
-			setNeedsRepaint();
+			simulatorWindow.setNeedsRepaint();
 		}
 		
 		if (lastPressed != null && lastPressedConsumed) {
 			return;
 		}
 		
-		setNeedsRepaint();
+		simulatorWindow.setNeedsRepaint();
 		
 		if (e.isShortcutDown()) {
 			isCtrlDown = true;
@@ -768,7 +755,7 @@ public class CircuitManager {
 		if (selectedElements.size() == 1 && !e.isShortcutDown()) {
 			GuiElement element = selectedElements.iterator().next();
 			element.keyTyped(this, circuitBoard.getCurrentState(), e.getCharacter());
-			setNeedsRepaint();
+			simulatorWindow.setNeedsRepaint();
 		}
 	}
 	
@@ -776,12 +763,12 @@ public class CircuitManager {
 		if (e.getCode().isModifierKey()) {
 			if (!e.isShortcutDown()) {
 				isCtrlDown = false;
-				setNeedsRepaint();
+				simulatorWindow.setNeedsRepaint();
 			}
 			if (!e.isShiftDown()) {
 				simulatorWindow.setClickMode(false);
 					isShiftDown = false;
-					setNeedsRepaint();
+					simulatorWindow.setNeedsRepaint();
 			}
 		}
 		
@@ -789,7 +776,7 @@ public class CircuitManager {
 			lastPressed.keyReleased(this, circuitBoard.getCurrentState(), e.getCode(), e.getText());
 			lastPressed = null;
 			lastPressedKeyCode = null;
-			setNeedsRepaint();
+			simulatorWindow.setNeedsRepaint();
 		}
 	}
 	
@@ -868,7 +855,7 @@ public class CircuitManager {
 			}
 			
 			if (startConnection != selected) {
-				setNeedsRepaint();
+				simulatorWindow.setNeedsRepaint();
 			}
 			
 			startConnection = selected;
@@ -885,7 +872,7 @@ public class CircuitManager {
 			if (currDiffX == 0 || prevDiffX == 0 ||
 			    currDiffX / Math.abs(currDiffX) != prevDiffX / Math.abs(prevDiffX)) {
 				if (isDraggedHorizontally) {
-					setNeedsRepaint();
+					simulatorWindow.setNeedsRepaint();
 				}
 				
 				isDraggedHorizontally = false;
@@ -894,7 +881,7 @@ public class CircuitManager {
 			if (currDiffY == 0 || prevDiffY == 0 ||
 			    currDiffY / Math.abs(currDiffY) != prevDiffY / Math.abs(prevDiffY)) {
 				if (!isDraggedHorizontally) {
-					setNeedsRepaint();
+					simulatorWindow.setNeedsRepaint();
 				}
 				
 				isDraggedHorizontally = true;
@@ -906,7 +893,7 @@ public class CircuitManager {
 				                            GuiUtils.getCircuitCoord(lastMousePosition.getY()));
 			
 			if (endConnection != connection) {
-				setNeedsRepaint();
+				simulatorWindow.setNeedsRepaint();
 			}
 			
 			endConnection = connection;
@@ -920,7 +907,7 @@ public class CircuitManager {
 			potentialComponent.setY(
 				GuiUtils.getCircuitCoord(lastMousePosition.getY()) - potentialComponent.getHeight() / 2);
 			
-			setNeedsRepaint();
+			simulatorWindow.setNeedsRepaint();
 		}
 	}
 
@@ -1041,7 +1028,7 @@ public class CircuitManager {
 				break;
 		}
 		
-		setNeedsRepaint();
+		simulatorWindow.setNeedsRepaint();
 	}
 	
 	public void mouseReleased(MouseEvent e) {
@@ -1111,7 +1098,7 @@ public class CircuitManager {
 		
 		checkStartConnection();
 		
-		setNeedsRepaint();
+		simulatorWindow.setNeedsRepaint();
 	}
 	
 	public void mouseDragged(MouseEvent e) {
@@ -1189,7 +1176,7 @@ public class CircuitManager {
 		
 		checkStartConnection();
 		
-		setNeedsRepaint();
+		simulatorWindow.setNeedsRepaint();
 	}
 	
 	private GuiElement lastEntered;
@@ -1199,7 +1186,7 @@ public class CircuitManager {
 		lastMousePosition = pixelToCanvasCoord(e.getX(), e.getY());
 		
 		if (currentState != SelectingState.IDLE) {
-			setNeedsRepaint();
+			simulatorWindow.setNeedsRepaint();
 		}
 		
 		updatePotentialComponent();
@@ -1225,30 +1212,30 @@ public class CircuitManager {
 					
 					(lastEntered = peer).mouseEntered(this, circuitBoard.getCurrentState());
 					
-					setNeedsRepaint();
+					simulatorWindow.setNeedsRepaint();
 				}
 			} else if (lastEntered != null) {
 				lastEntered.mouseExited(this, circuitBoard.getCurrentState());
 				lastEntered = null;
 				
-				setNeedsRepaint();
+				simulatorWindow.setNeedsRepaint();
 			}
 		} else if (lastEntered != null) {
 			lastEntered.mouseExited(this, circuitBoard.getCurrentState());
 			lastEntered = null;
 			
-			setNeedsRepaint();
+			simulatorWindow.setNeedsRepaint();
 		}
 	}
 	
 	public void mouseEntered(MouseEvent e) {
 		isMouseInsideCanvas = true;
-		setNeedsRepaint();
+		simulatorWindow.setNeedsRepaint();
 	}
 	
 	public void mouseExited(MouseEvent e) {
 		isMouseInsideCanvas = false;
-		setNeedsRepaint();
+		simulatorWindow.setNeedsRepaint();
 	}
 	
 	public void mouseWheelScrolled(ScrollEvent e) {
@@ -1270,7 +1257,7 @@ public class CircuitManager {
 		mouseExited(null);
 		simulatorWindow.setClickMode(false);
 		resetLastPressed();
-		setNeedsRepaint();
+		simulatorWindow.setNeedsRepaint();
 	}
 
 	public void contextMenuRequested(ContextMenuEvent e) {

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -98,6 +98,7 @@ import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.control.TabPane.TabClosingPolicy;
+import javafx.scene.control.TabPane.TabDragPolicy;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextInputDialog;
 import javafx.scene.control.ToggleButton;
@@ -2022,6 +2023,7 @@ public class CircuitSim extends Application {
 		canvasTabPane = new TabPane();
 		canvasTabPane.setPrefWidth(800);
 		canvasTabPane.setPrefHeight(600);
+		canvasTabPane.setTabDragPolicy(TabDragPolicy.REORDER);
 		canvasTabPane.setTabClosingPolicy(TabClosingPolicy.ALL_TABS);
 		canvasTabPane.widthProperty().addListener((observable, oldValue, newValue) -> needsRepaint = true);
 		canvasTabPane.heightProperty().addListener((observable, oldValue, newValue) -> needsRepaint = true);

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -389,6 +389,10 @@ public class CircuitSim extends Application {
 		}
 	}
 	
+	void setNeedsRepaint() {
+		needsRepaint = true;
+	}
+
 	/**
 	 * Get all circuits.
 	 *
@@ -2669,9 +2673,9 @@ public class CircuitSim extends Application {
 					
 					CircuitManager manager = getCurrentCircuit();
 					if (manager != null) {
-						if ((needsRepaint || manager.needsRepaint())) {
-							needsRepaint = false;
+						if (needsRepaint) {
 							simulator.runSync(manager::paint);
+							needsRepaint = false;
 						}
 						
 						if (!loadingFile) {

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -2165,7 +2165,7 @@ public class CircuitSim extends Application {
 								return;
 							}
 
-							manager.paint(circuitCanvas.getGraphicsContext2D());
+							manager.paint(circuitCanvas);
 							Image image = circuitCanvas.snapshot(null, null);
 							RenderedImage rendered = SwingFXUtils.fromFXImage(image, null);
 							images.put(name, rendered);
@@ -2674,8 +2674,8 @@ public class CircuitSim extends Application {
 					CircuitManager manager = getCurrentCircuit();
 					if (manager != null) {
 						if (needsRepaint) {
-							simulator.runSync(manager::paint);
 							needsRepaint = false;
+							simulator.runSync(() -> manager.paint(circuitCanvas));
 						}
 						
 						if (!loadingFile) {

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -363,29 +363,29 @@ public class CircuitSim extends Application {
 	void zoomIn(double x, double y) {
 		int selectedIndex = scaleFactorSelect.getSelectionModel().getSelectedIndex();
 		if (selectedIndex < scaleFactorSelect.getItems().size()) {
+			double oldZoom = scaleFactorSelect.getSelectionModel().getSelectedItem();
 			scaleFactorSelect.getSelectionModel().select(selectedIndex + 1);
+			double newZoom = scaleFactorSelect.getSelectionModel().getSelectedItem();
 			
-			setScrollPosition(x, y);
+			setScrollPosition(x, y, oldZoom, newZoom);
 		}
 	}
 	
 	void zoomOut(double x, double y) {
 		int selectedIndex = scaleFactorSelect.getSelectionModel().getSelectedIndex();
 		if (selectedIndex > 0) {
+			double oldZoom = scaleFactorSelect.getSelectionModel().getSelectedItem();
 			scaleFactorSelect.getSelectionModel().select(selectedIndex - 1);
+			double newZoom = scaleFactorSelect.getSelectionModel().getSelectedItem();
 			
-			setScrollPosition(x, y);
+			setScrollPosition(x, y, oldZoom, newZoom);
 		}
 	}
 	
-	private void setScrollPosition(double x, double y) {
+	private void setScrollPosition(double x, double y, double oldZoom, double newZoom) {
 		CircuitManager manager = getCurrentCircuit();
 		if (manager != null) {
-			ScrollPane scrollPane = manager.getCanvasScrollPane();
-			Canvas canvas = manager.getCanvas();
-			
-			scrollPane.setHvalue(scrollPane.getHmax() * x / canvas.getWidth());
-			scrollPane.setVvalue(scrollPane.getVmax() * y / canvas.getHeight());
+			manager.zoomInOnPoint(x, y, oldZoom, newZoom);
 		}
 	}
 	

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -2156,11 +2156,12 @@ public class CircuitSim extends Application {
 					runFxSync(() -> simulator.runSync(() -> {
 						circuitManagers.forEach((name, pair) -> {
 							CircuitManager manager = pair.getValue();
-							manager.setTranslate(Point2D.ZERO);
-							setScaleFactor(1.0);
 							
-							Bounds circuitBounds = pair.getValue().getMaxCircuitBounds();
-
+							Bounds circuitBounds = pair.getValue().getCircuitBounds();
+							Point2D newOrigin = new Point2D(circuitBounds.getMinX(), circuitBounds.getMinY())
+								.multiply(-GuiUtils.BLOCK_SIZE);
+							manager.setTranslate(newOrigin);
+							setScaleFactor(1.0);
 							try {
 								circuitCanvas.setWidth(circuitBounds.getWidth() * getScaleFactor() * GuiUtils.BLOCK_SIZE);
 								circuitCanvas.setHeight(circuitBounds.getHeight() * getScaleFactor() * GuiUtils.BLOCK_SIZE);
@@ -2173,6 +2174,8 @@ public class CircuitSim extends Application {
 							Image image = circuitCanvas.snapshot(null, null);
 							RenderedImage rendered = SwingFXUtils.fromFXImage(image, null);
 							images.put(name, rendered);
+
+							manager.setTranslate(Point2D.ZERO);
 						});
 						updateCanvasSize();
 					}));

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -935,54 +935,10 @@ public class CircuitSim extends Application {
 				return;
 			}
 
-			// Computes the rendered size of the circuit, adjusting the size of the canvas to take account.
-			// The canvas will be at minimum the size of the render window and at maximum 4x the size of the render window.
-			// This is done because immensely large canvas (~5000x5000 on macOS ARM) can cause OOM errors, namely:
-			//     java.lang.NullPointerException: 
-			//     Cannot invoke "com.sun.prism.RTTexture.createGraphics()" because "<local9>" is null
-			//
-			// This does cause a minor issue:
-			//     If a circuit is too large (or if you are zoomed in too closely),
-			//     you will not be able to access the entire circuit from the window.
-			//
-			//     This is fine because realistically, most of the circuits we use should be small enough
-			//     for this to not matter.
-			//     For larger circuits, you can zoom-out to access a different part of the circuit.
-			int maxX = Stream
-				.concat(circuitManager.getSelectedElements().stream(),
-				        Stream.concat(circuitManager.getCircuitBoard().getComponents().stream(),
-				                      circuitManager
-					                      .getCircuitBoard()
-					                      .getLinks()
-					                      .stream()
-					                      .flatMap(links -> links.getWires().stream())))
-				.mapToInt(componentPeer -> componentPeer.getX() + componentPeer.getWidth())
-				.max()
-				.orElse(0);
-			
-			double minWidth = circuitManager.getCanvasScrollPane().getWidth(); // size of pane
-			double maxWidth = 4 * minWidth;
-			double clampedWidth = Math.min(Math.max(minWidth, getScaleFactor() * (maxX + 5) * GuiUtils.BLOCK_SIZE), maxWidth);
-
-			circuitManager.getCanvas().setWidth(clampedWidth);
-			
-			int maxY = Stream
-				.concat(circuitManager.getSelectedElements().stream(),
-				        Stream.concat(circuitManager.getCircuitBoard().getComponents().stream(),
-				                      circuitManager
-					                      .getCircuitBoard()
-					                      .getLinks()
-					                      .stream()
-					                      .flatMap(links -> links.getWires().stream())))
-				.mapToInt(componentPeer -> componentPeer.getY() + componentPeer.getHeight())
-				.max()
-				.orElse(0);
-			
-			double minHeight = circuitManager.getCanvasScrollPane().getHeight(); // size of pane
-			double maxHeight = 4 * minHeight;
-			double clampedHeight = Math.min(Math.max(minHeight, getScaleFactor() * (maxY + 5) * GuiUtils.BLOCK_SIZE), maxHeight);
-
-			circuitManager.getCanvas().setHeight(clampedHeight);
+			double paneWidth = circuitManager.getCanvasScrollPane().getWidth();
+			circuitManager.getCanvas().setWidth(paneWidth);
+			double paneHeight = circuitManager.getCanvasScrollPane().getHeight();
+			circuitManager.getCanvas().setHeight(paneHeight);
 			
 			needsRepaint = true;
 		});
@@ -2036,7 +1992,6 @@ public class CircuitSim extends Application {
 		scaleFactorSelect.setValue(1.0);
 		scaleFactorSelect.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
 			needsRepaint = true;
-			updateCanvasSize(getCurrentCircuit());
 		});
 		
 		buttonTabPane = new TabPane();

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -935,6 +935,19 @@ public class CircuitSim extends Application {
 				return;
 			}
 
+			// Computes the rendered size of the circuit, adjusting the size of the canvas to take account.
+			// The canvas will be at minimum the size of the render window and at maximum 4x the size of the render window.
+			// This is done because immensely large canvas (~5000x5000 on macOS ARM) can cause OOM errors, namely:
+			//     java.lang.NullPointerException: 
+			//     Cannot invoke "com.sun.prism.RTTexture.createGraphics()" because "<local9>" is null
+			//
+			// This does cause a minor issue:
+			//     If a circuit is too large (or if you are zoomed in too closely),
+			//     you will not be able to access the entire circuit from the window.
+			//
+			//     This is fine because realistically, most of the circuits we use should be small enough
+			//     for this to not matter.
+			//     For larger circuits, you can zoom-out to access a different part of the circuit.
 			int maxX = Stream
 				.concat(circuitManager.getSelectedElements().stream(),
 				        Stream.concat(circuitManager.getCircuitBoard().getComponents().stream(),
@@ -947,8 +960,11 @@ public class CircuitSim extends Application {
 				.max()
 				.orElse(0);
 			
-			double maxWidth = Math.min(5000, getScaleFactor() * (maxX + 5) * GuiUtils.BLOCK_SIZE);
-			circuitManager.getCanvas().setWidth(Math.max(maxWidth, circuitManager.getCanvasScrollPane().getWidth()));
+			double minWidth = circuitManager.getCanvasScrollPane().getWidth(); // size of pane
+			double maxWidth = 4 * minWidth;
+			double clampedWidth = Math.min(Math.max(minWidth, getScaleFactor() * (maxX + 5) * GuiUtils.BLOCK_SIZE), maxWidth);
+
+			circuitManager.getCanvas().setWidth(clampedWidth);
 			
 			int maxY = Stream
 				.concat(circuitManager.getSelectedElements().stream(),
@@ -962,9 +978,11 @@ public class CircuitSim extends Application {
 				.max()
 				.orElse(0);
 			
-			double maxHeight = Math.min(5000, getScaleFactor() * (maxY + 5) * GuiUtils.BLOCK_SIZE);
-			circuitManager.getCanvas().setHeight(Math.max(maxHeight,
-			                                              circuitManager.getCanvasScrollPane().getHeight()));
+			double minHeight = circuitManager.getCanvasScrollPane().getHeight(); // size of pane
+			double maxHeight = 4 * minHeight;
+			double clampedHeight = Math.min(Math.max(minHeight, getScaleFactor() * (maxY + 5) * GuiUtils.BLOCK_SIZE), maxHeight);
+
+			circuitManager.getCanvas().setHeight(clampedHeight);
 			
 			needsRepaint = true;
 		});

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -1815,7 +1815,7 @@ public class CircuitSim extends Application {
 		}
 		
 		runFxSync(() -> {
-			CircuitManager circuitManager = new CircuitManager(name, this, this.canvasScrollPane, simulator, showGridProp);
+			CircuitManager circuitManager = new CircuitManager(name, this, simulator, showGridProp);
 			circuitManager.getCircuit().addListener(this::circuitModified);
 			
 			// If name already exists, add a number to the name until it doesn't exist.

--- a/src/main/java/com/ra4king/circuitsim/gui/GuiUtils.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/GuiUtils.java
@@ -91,10 +91,31 @@ public class GuiUtils {
 		}
 	}
 	
+	/**
+	 * Converts a coordinate value in the canvas coordinate system to the circuit coordinate system.
+	 * 
+	 * See CircuitManager for details about the coordinate systems.
+	 * 
+	 * @param a a canvas coordinate value
+	 * @return a circuit coordinate value
+	 * 
+	 * @see com.ra4king.circuitsim.gui.CircuitManager CircuitManager
+	 */
 	public static int getCircuitCoord(double a) {
 		return ((int)Math.round(a) + BLOCK_SIZE / 2) / BLOCK_SIZE;
 	}
 	
+	/**
+	 * Converts a coordinate value in the canvas coordinate system to the canvas coordinate
+	 * that corresponds to the center of the circuit tile.
+	 * 
+	 * See CircuitManager for details about the coordinate systems.
+	 * 
+	 * @param a a canvas coordinate value
+	 * @return a new canvas coordinate value
+	 * 
+	 * @see com.ra4king.circuitsim.gui.CircuitManager CircuitManager
+	 */
 	public static int getScreenCircuitCoord(double a) {
 		return getCircuitCoord(a) * BLOCK_SIZE;
 	}


### PR DESCRIPTION
This PR improves the rendering of the circuit on the Canvas as well as implements gestures that make it easier to move around the Canvas. In particular, this PR...
- rewrites Canvas rendering to use 1 fixed-size Canvas per window instead of 1 dynamic-size Canvas per Circuit
- Implements smooth panning & zooming
- Implements panning and zooming gestures

Notably, this PR fixes a very frequent crash caused by rendering large circuits or rendering on high zoom:
```
java.lang.NullPointerException: Cannot invoke "com.sun.prism.RTTexture.createGraphics()" because "<local9>" is null
```

This also applies upstream.
