### PR TITLE
Set Constant value to default to display base instead of decimal

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/gui/Properties.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/Properties.java
@@ -384,7 +384,7 @@ public class Properties {
 					try {
 						onAction.accept(parse(newValue));
 					} catch (Exception exc) {
-						exc.printStackTrace();
+						System.err.println("Input error: " + exc.getMessage());
 						valueField.setText(toString(value));
 					}
 				}

--- a/src/main/java/com/ra4king/circuitsim/gui/Properties.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/Properties.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 
 import com.ra4king.circuitsim.gui.properties.IntegerString;
+import com.ra4king.circuitsim.gui.properties.IntegerString.IntegerStringValidator;
 import com.ra4king.circuitsim.gui.properties.PropertyListValidator;
 import com.ra4king.circuitsim.gui.properties.PropertyValidators;
 
@@ -224,7 +225,12 @@ public class Properties {
 	}
 	
 	public enum Base {
-		BINARY, HEXADECIMAL, DECIMAL
+		BINARY(2), HEXADECIMAL(16), DECIMAL(10);
+
+		public final int value;
+		private Base(int value) {
+			this.value = value;
+		}
 	}
 	
 	static {
@@ -263,14 +269,28 @@ public class Properties {
 		
 		BASE = new Property<>("Base", "Display Base", new PropertyListValidator<>(Base.values()), Base.BINARY);
 		
-		VALUE = new Property<>(
-			"Value",
-			"Value",
-			"Three input formats supported: decimal, hexadecimal (with 0x prefix), and binary " + "(with 0b prefix).",
-			PropertyValidators.INTEGER_VALIDATOR,
-			new IntegerString(0));
+		VALUE = Properties.VALUE(10);
 	}
 	
+	/**
+	 * A generic integer input.
+	 * @param defaultBase The default base to interpret the string as. 
+	 * (Note: the `Properties.VALUE` static field exists which is equivalent to `Properties.VALUE(10)`).
+	 * 
+	 * There should only be one `VALUE` input per peer (since they all use the same "Value" property name).
+	 * 
+	 * @return the Property representing this generic integer input.
+	 */
+	public static Property<IntegerString> VALUE(int defaultBase) {
+		return new Property<>(
+			"Value",
+			"Value",
+			"Three input formats supported: decimal, hexadecimal (with 0x prefix), and binary (with 0b prefix).",
+			new IntegerStringValidator(defaultBase),
+			new IntegerString(0)
+		);
+	}
+
 	public static class Property<T> {
 		public final String name;
 		public String display;

--- a/src/main/java/com/ra4king/circuitsim/gui/peers/wiring/ConstantPeer.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/peers/wiring/ConstantPeer.java
@@ -7,7 +7,10 @@ import com.ra4king.circuitsim.gui.ComponentManager.ComponentManagerInterface;
 import com.ra4king.circuitsim.gui.ComponentPeer;
 import com.ra4king.circuitsim.gui.Connection.PortConnection;
 import com.ra4king.circuitsim.gui.GuiUtils;
+import com.ra4king.circuitsim.gui.properties.IntegerString;
 import com.ra4king.circuitsim.gui.Properties;
+import com.ra4king.circuitsim.gui.Properties.Base;
+import com.ra4king.circuitsim.gui.Properties.Property;
 import com.ra4king.circuitsim.simulator.CircuitState;
 import com.ra4king.circuitsim.simulator.WireValue;
 import com.ra4king.circuitsim.simulator.components.wiring.Constant;
@@ -39,16 +42,29 @@ public class ConstantPeer extends ComponentPeer<Constant> {
 		properties.ensureProperty(Properties.DIRECTION);
 		properties.ensureProperty(Properties.BITSIZE);
 		properties.ensureProperty(Properties.BASE);
-		properties.ensureProperty(Properties.VALUE);
 		properties.mergeIfExists(props);
+
+		// Value property:
+		// This property is a bit different, since
+		// it depends on the value of BASE and its input text changes when BASE changes.
+		//
+		// To handle this, we will create and merge the value property separately.
+		Base base = properties.getValue(Properties.BASE);
+		Property<IntegerString> valueProperty = Properties.VALUE(base.value);
+		properties.ensureProperty(valueProperty);
+		
+		IntegerString oldValue = props.getValue(valueProperty.name);
+		if (oldValue != null) {
+			properties.parseAndSetValue(valueProperty, oldValue.prefixedString());
+		}
 		
 		Constant constant = new Constant(
 			properties.getValue(Properties.LABEL),
 			properties.getValue(Properties.BITSIZE),
-			properties.getValue(Properties.VALUE).getValue());
+			properties.getValue(valueProperty).getValue());
 		
 		int bitSize = constant.getBitSize();
-		switch (properties.getValue(Properties.BASE)) {
+		switch (base) {
 			case BINARY -> {
 				setWidth(Math.max(2, Math.min(8, bitSize)));
 				setHeight((int)Math.round((1 + (bitSize - 1) / 8) * 1.5));

--- a/src/main/java/com/ra4king/circuitsim/gui/properties/IntegerString.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/properties/IntegerString.java
@@ -3,6 +3,7 @@ package com.ra4king.circuitsim.gui.properties;
 import java.util.Objects;
 
 import com.ra4king.circuitsim.simulator.SimulationException;
+import com.ra4king.circuitsim.gui.Properties.PropertyValidator;
 
 /**
  * A wrapper around integers which can be constructed from strings of different bases.
@@ -135,5 +136,34 @@ public final class IntegerString {
 	@Override
 	public String toString() {
 		return this.valueString;
+	}
+
+	public static final class IntegerStringValidator implements PropertyValidator<IntegerString> {
+		private final int base;
+		public IntegerStringValidator() {
+			this(10);
+		}
+		public IntegerStringValidator(int base) {
+			this.base = base;
+		}
+
+		@Override
+		public int hashCode() {
+			return Integer.hashCode(this.base);
+		}
+		
+		@Override
+		public boolean equals(Object other) {
+			if (other instanceof IntegerStringValidator) {
+				IntegerStringValidator validator = (IntegerStringValidator) other;
+				return this.base == validator.base;
+			}
+			
+			return true;
+		}
+		@Override
+		public IntegerString parse(String value) {
+			return new IntegerString(value, this.base);
+		}
 	}
 }

--- a/src/main/java/com/ra4king/circuitsim/gui/properties/IntegerString.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/properties/IntegerString.java
@@ -108,6 +108,28 @@ public final class IntegerString {
 		this.valueString = Integer.toString(value);
 	}
 	
+	/**
+	 * Similar to default parsing, 
+	 * but unprefixed values are parsed as base-10 and converted to their display base.
+	 * 
+	 * @param valueString the string to parse
+	 * @param defaultBase the display base
+	 */
+	public static IntegerString parseFromLegacy(String valueString, int base) {
+		// Cast value and force prefix:
+		IntegerString valStr = new IntegerString(valueString, 10);
+		String string = valStr.toString(base);
+		if (!valStr.prefixed) {
+			string = switch (base) {
+				case 2 -> "0b" + string;
+				case 16 -> "0x" + string;
+				default -> string;
+			};
+		}
+		
+		return new IntegerString(string, base);
+	}
+
 	public int getValue() {
 		return value;
 	}

--- a/src/main/java/com/ra4king/circuitsim/gui/properties/IntegerString.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/properties/IntegerString.java
@@ -1,8 +1,12 @@
 package com.ra4king.circuitsim.gui.properties;
 
+import java.util.Objects;
+
 import com.ra4king.circuitsim.simulator.SimulationException;
 
 /**
+ * A wrapper around integers which can be constructed from strings of different bases.
+ * 
  * @author Roi Atalla
  */
 public final class IntegerString {
@@ -10,40 +14,88 @@ public final class IntegerString {
 	private final int value;
 	private final int base;
 	
-	public IntegerString(String value) {
-		String valueToParse;
-		if (value.startsWith("0x")) {
-			base = 16;
-			valueString = value;
-			valueToParse = value.substring(2);
-		} else if (value.startsWith("x")) {
-			base = 16;
-			valueString = "0" + value;
-			valueToParse = value.substring(1);
-		} else if (value.startsWith("0b")) {
-			base = 2;
-			valueString = value;
-			valueToParse = value.substring(2);
-		} else if (value.startsWith("b")) {
-			base = 2;
-			valueString = "0" + value;
-			valueToParse = value.substring(1);
-		} else {
-			base = 10;
-			valueString = valueToParse = value;
-		}
+	/**
+	 * Creates an integer out of a string.
+	 * This infers the base of the integer using the string prefix:
+	 * - '#' or no prefix indicates a decimal number,
+	 * - '0x' or 'x' indicates a hexadecimal integer,
+	 * - '0b' or 'b' indicates a binary number.
+	 * 
+	 * @param valueString the string to parse
+	 */
+	public IntegerString(String valueString) {
+		this(valueString, 10);
+	}
+	/**
+	 * Creates an integer out of a string.
+	 * 
+	 * For prefixed integer strings (e.g., '0xDEADBEEF', '0b100000111110', '#123'),
+	 * the base is inferred.
+	 * 
+	 * If there is no prefix, then the base defaults to the defaultBase parameter.
+	 * 
+	 * @param valueString the string to parse
+	 * @param defaultBase the default base, if no prefix provided
+	 */
+	public IntegerString(String valueString, int defaultBase) {
+		int base = defaultBase;
+		boolean isNegative = valueString.startsWith("-");
 		
+		// Compute negative and base-override, if prefixes are present:
+		if (isNegative) {
+			valueString = valueString.substring(1);
+		}
+		if (valueString.startsWith("0x")) {
+			base = 16;
+			valueString = valueString.substring(2);
+		} else if (valueString.startsWith("x")) {
+			base = 16;
+			valueString = valueString.substring(1);
+		} else if (valueString.startsWith("0b")) {
+			base = 2;
+			valueString = valueString.substring(2);
+		} else if (valueString.startsWith("b")) {
+			base = 2;
+			valueString = valueString.substring(1);
+		} else if (valueString.startsWith("#")) {
+			base = 10;
+			valueString = valueString.substring(1);
+		}
+		// Check negative after prefix
+		if (!isNegative && valueString.startsWith("-")) {
+			isNegative = true;
+			valueString = valueString.substring(1);
+		}
+
+		// Parse value:
 		try {
-			this.value = (int)Long.parseLong(valueToParse, base);
+			this.value = (isNegative ? -1 : 1) * Integer.parseUnsignedInt(valueString, base);
 		} catch (NumberFormatException exc) {
 			throw new SimulationException(valueString + " is not a valid value of base " + base);
 		}
+		this.base = base;
+		// Readd prefixes (note this converts 'x' and 'b' to '0x' and '0b'):
+		String negPrefix = isNegative ? "-" : "";
+		String basePrefix = "";
+		if (base != defaultBase) {
+			basePrefix = switch (base) {
+				case 2 -> "0b";
+				case 10 -> "#";
+				case 16 -> "0x";
+				default -> "";
+			};
+		}
+		this.valueString = negPrefix + basePrefix + valueString;
 	}
 	
+	/**
+	 * Creates a new `IntegerString` from a base-10 integer.
+	 * @param value the integer
+	 */
 	public IntegerString(int value) {
 		this.value = value;
 		this.base = 10;
-		valueString = Integer.toString(value);
+		this.valueString = Integer.toString(value);
 	}
 	
 	public int getValue() {
@@ -54,27 +106,34 @@ public final class IntegerString {
 		return base;
 	}
 	
-	public String getValueString() {
-		return valueString;
+	/**
+	 * @return the string representation of this value (with an explicit prefix)
+	 */
+	public String prefixedString() {
+		return switch (base) {
+			case 2  -> String.format("0b%s", Integer.toString(value, 2));
+			case 10 -> String.format("#%d", value);
+			case 16 -> String.format("0x%X", value);
+			default -> Integer.toString(value);
+		};
 	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (o instanceof IntegerString) {
-			IntegerString other = (IntegerString)o;
-			return other.valueString.equals(this.valueString);
+			IntegerString other = (IntegerString) o;
+			return this.value == other.value && this.base == other.base;
 		}
-		
 		return false;
 	}
 	
 	@Override
 	public int hashCode() {
-		return valueString.hashCode();
+		return Objects.hash(value, base);
 	}
 	
 	@Override
 	public String toString() {
-		return valueString;
+		return this.valueString;
 	}
 }

--- a/src/main/java/com/ra4king/circuitsim/gui/properties/PropertyValidators.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/properties/PropertyValidators.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.function.Consumer;
 
 import com.ra4king.circuitsim.gui.Properties.PropertyValidator;
+import com.ra4king.circuitsim.gui.properties.IntegerString.IntegerStringValidator;
 
 import javafx.scene.Node;
 import javafx.scene.control.ColorPicker;
@@ -16,7 +17,7 @@ import javafx.stage.Stage;
  * @author Roi Atalla
  */
 public final class PropertyValidators {
-	public static final PropertyValidator<IntegerString> INTEGER_VALIDATOR = IntegerString::new;
+	public static final PropertyValidator<IntegerString> INTEGER_VALIDATOR = new IntegerStringValidator();
 	public static final PropertyValidator<String> ANY_STRING_VALIDATOR = value -> value;
 	public static final PropertyValidator<Boolean> YESNO_VALIDATOR = new PropertyListValidator<>(new Boolean[] {
 		true, false


### PR DESCRIPTION
Related to https://github.com/ra4king/CircuitSim/issues/97. This can be ported upstream.

Note that this is not backwards compatible with previous versions (since decimal constants in older versions will be interpreted in the display base with this PR). This results in possible deletion of constant values in cases where the display is in binary but the value is a decimal value which cannot be parsed as binary.