### PR TITLE
Improved pathfinding

### DIFF
--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitBoard.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitBoard.java
@@ -19,7 +19,6 @@ import com.ra4king.circuitsim.gui.Connection.WireConnection;
 import com.ra4king.circuitsim.gui.EditHistory.EditAction;
 import com.ra4king.circuitsim.gui.LinkWires.Wire;
 import com.ra4king.circuitsim.gui.PathFinding.LocationPreference;
-import com.ra4king.circuitsim.gui.PathFinding.Point;
 import com.ra4king.circuitsim.simulator.Circuit;
 import com.ra4king.circuitsim.simulator.CircuitState;
 import com.ra4king.circuitsim.simulator.SimulationException;
@@ -467,7 +466,7 @@ public class CircuitBoard {
 					
 					final int sx = sourceX;
 					final int sy = sourceY;
-					Pair<Set<Wire>, Set<Point>> pair = PathFinding.bestPath(sx, sy, x, y, (px, py, horizontal) -> {
+					Set<Wire> path = PathFinding.bestPath(sx, sy, x, y, (px, py, horizontal) -> {
 						if (px == x && py == y) {
 							return LocationPreference.VALID;
 						}
@@ -518,8 +517,8 @@ public class CircuitBoard {
 						
 						return LocationPreference.VALID;
 					});
-					if (pair != null) {
-						paths.addAll(pair.getKey());
+					if (path != null) {
+						paths.addAll(path);
 					}
 				}
 				

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitManager.java
@@ -631,23 +631,31 @@ public class CircuitManager {
 
 		switch (e.getCode()) {
 			case RIGHT: {
-				e.consume();
-				handleArrowPressed(Direction.EAST);
+				if (currentState != SelectingState.ELEMENT_DRAGGED) {
+					e.consume();
+					handleArrowPressed(Direction.EAST);
+				}
 				break;
 			}
 			case LEFT: {
-				e.consume();
-				handleArrowPressed(Direction.WEST);
+				if (currentState != SelectingState.ELEMENT_DRAGGED) {
+					e.consume();
+					handleArrowPressed(Direction.WEST);
+				}
 				break;
 			}
 			case UP: {
-				e.consume();
-				handleArrowPressed(Direction.NORTH);
+				if (currentState != SelectingState.ELEMENT_DRAGGED) {
+					e.consume();
+					handleArrowPressed(Direction.NORTH);
+				}
 				break;
 			}
 			case DOWN: {
-				e.consume();
-				handleArrowPressed(Direction.SOUTH);
+				if (currentState != SelectingState.ELEMENT_DRAGGED) {
+					e.consume();
+					handleArrowPressed(Direction.SOUTH);
+				}
 				break;
 			}
 			case SHIFT:
@@ -671,6 +679,8 @@ public class CircuitManager {
 				}
 				
 				reset();
+				break;
+			default:
 				break;
 		}
 	}

--- a/src/main/java/com/ra4king/circuitsim/gui/Connection.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/Connection.java
@@ -58,6 +58,16 @@ public abstract class Connection {
 		return 6;
 	}
 	
+	/**
+	 * Checks if this connection is at the given circuit coordinates.
+	 * @param x the X coord
+	 * @param y the Y coord
+	 * @return whether this connection is at this coordinate.
+	 */
+	public boolean isAt(int x, int y) {
+		return this.getX() == x && this.getY() == y;
+	}
+
 	public void paint(GraphicsContext graphics, CircuitState circuitState) {
 		GuiUtils.setBitColor(graphics, circuitState, getLinkWires());
 		graphics.fillOval(getScreenX(), getScreenY(), getScreenWidth(), getScreenHeight());

--- a/src/main/java/com/ra4king/circuitsim/gui/GuiElement.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/GuiElement.java
@@ -72,12 +72,12 @@ public abstract class GuiElement {
 	}
 	
 	public boolean containsScreenCoord(int x, int y) {
-		return x >= getScreenX() && x < getScreenX() + getScreenWidth() && y >= getScreenY() &&
-		       y < getScreenY() + getScreenHeight();
+		return x >= getScreenX() && x <= getScreenX() + getScreenWidth() && y >= getScreenY() &&
+		       y <= getScreenY() + getScreenHeight();
 	}
 	
 	public boolean contains(int x, int y) {
-		return x >= getX() && x < getX() + getWidth() && y >= getY() && y < getY() + getHeight();
+		return x >= getX() && x <= getX() + getWidth() && y >= getY() && y <= getY() + getHeight();
 	}
 	
 	public boolean contains(GuiElement element) {

--- a/src/main/java/com/ra4king/circuitsim/gui/PathFinding.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/PathFinding.java
@@ -107,7 +107,11 @@ public final class PathFinding {
 					continue;
 				}
 
-				int additionalLength = preference == LocationPreference.PREFER ? 0 : 1;
+				int additionalLength = switch (preference) {
+					case PREFER -> 0;
+					case VALID -> 1;
+					case INVALID -> 999;
+				};
 				
 				int additionalTurns = 0;
 				if (current.directionEntered != null && direction != current.directionEntered) {

--- a/src/main/java/com/ra4king/circuitsim/gui/PathFinding.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/PathFinding.java
@@ -1,6 +1,5 @@
 package com.ra4king.circuitsim.gui;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -9,8 +8,6 @@ import java.util.PriorityQueue;
 import java.util.Set;
 
 import com.ra4king.circuitsim.gui.LinkWires.Wire;
-
-import javafx.util.Pair;
 
 /**
  * @author Roi Atalla
@@ -52,12 +49,11 @@ public final class PathFinding {
 	 * @param dy destination y
 	 * @param callback a callback which indicates 
 	 *     whether a wire can be placed at a given point and orientation
-	 * @return a Pair, consisting of the set of wires that form the path 
-	 *     and the set of points visited during the traversal process.
+	 * @return the set of wires that form the best path between the two points
 	 */
-	public static Pair<Set<Wire>, Set<Point>> bestPath(int sx, int sy, int dx, int dy, ValidWireLocation callback) {
+	public static Set<Wire> bestPath(int sx, int sy, int dx, int dy, ValidWireLocation callback) {
 		if (dx < 0 || dy < 0) {
-			return new Pair<>(Collections.emptySet(), Collections.emptySet());
+			return Set.of();
 		}
 		
 		Point source = new Point(sx, sy);
@@ -74,13 +70,13 @@ public final class PathFinding {
 		int iterations = 0;
 		while (!frontier.isEmpty()) {
 			if (Thread.currentThread().isInterrupted()) {
-				return new Pair<>(Collections.emptySet(), parents.keySet());
+				return Set.of();
 			}
 			
 			iterations++;
 			if (iterations == 5000) {
 				System.err.println("Path finding taking too long, bail...");
-				return new Pair<>(Collections.emptySet(), parents.keySet());
+				return Set.of();
 			}
 
 			Node current = frontier.poll();
@@ -91,7 +87,7 @@ public final class PathFinding {
 			parents.put(current.point, current.parent);
 
 			if (destination.equals(current.point)) {
-				return new Pair<>(constructPath(parents, current.point), parents.keySet());
+				return constructPath(parents, current.point);
 			}
 
 			// Add neighbors

--- a/src/main/java/com/ra4king/circuitsim/gui/PathFinding.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/PathFinding.java
@@ -24,6 +24,17 @@ public class PathFinding {
 	
 	private static final Cost INFINITY = new Cost(Integer.MAX_VALUE, Integer.MAX_VALUE);
 	
+	/**
+	 * Computes the best path between the source point and destination point.
+	 * @param sx source x
+	 * @param sy source y
+	 * @param dx destination x
+	 * @param dy destination y
+	 * @param valid a callback which indicates 
+	 *     whether a wire can be placed at a given point and orientation
+	 * @return a Pair, consisting of the set of wires that form the path 
+	 *     and the set of points visited during the traversal process.
+	 */
 	public static Pair<Set<Wire>, Set<Point>> bestPath(int sx, int sy, int dx, int dy, ValidWireLocation valid) {
 		if (dx < 0 || dy < 0) {
 			return new Pair<>(Collections.emptySet(), Collections.emptySet());

--- a/src/test/java/com/ra4king/circuitsim/gui/PathFindingTest.java
+++ b/src/test/java/com/ra4king/circuitsim/gui/PathFindingTest.java
@@ -27,7 +27,7 @@ public class PathFindingTest {
 			return LocationPreference.VALID;
 		};
 		
-		assertThat(PathFinding.bestPath(3, 0, 3, 6, validFn).getKey()).containsExactly(new Wire(null, 3, 6, 2, true),
+		assertThat(PathFinding.bestPath(3, 0, 3, 6, validFn)).containsExactly(new Wire(null, 3, 6, 2, true),
 		                                                                               new Wire(null, 3, 0, 2, true),
 		                                                                               new Wire(null, 5, 0, 6, false));
 	}
@@ -50,7 +50,7 @@ public class PathFindingTest {
 			return LocationPreference.VALID;
 		};
 		
-		assertThat(PathFinding.bestPath(0, 0, 5, 3, validFn).getKey()).containsExactly(new Wire(null, 0, 0, 6, false),
+		assertThat(PathFinding.bestPath(0, 0, 5, 3, validFn)).containsExactly(new Wire(null, 0, 0, 6, false),
 		                                                                               new Wire(null, 0, 6, 6, true),
 		                                                                               new Wire(null, 6, 3, 3, false),
 		                                                                               new Wire(null, 5, 3, 1, true));


### PR DESCRIPTION
Improves wire pathfinding. This can be ported upstream. The notable fixes here are:
- The pathfinding algorithm in general was rewritten to a more-traditional implementation of A* (y'know if we bump minimum Java to 17 we could use records :eyes:)
- Wires won't accidentally overlap with ports of moved elements
- Moving a component and moving it back doesn't catastrophically destroy the circuit
- Moving components doesn't make me feel (as) sad

There are some bugs with pathfinding still:
- Pathfinding wires will not snap to preexisting wires unless it is the optimal path (introduced bug)
- Connecting two ports on a line and attaching another port onto the line and then moving it will perform odd behaviors (already present bug; observe what happens if you attach the new port onto a preexisting port and also on the line)

