### PR TITLE
Improve UI readability

### DIFF
--- a/src/main/kotlin/com/ra4king/circuitsim/gui/AppContext.kt
+++ b/src/main/kotlin/com/ra4king/circuitsim/gui/AppContext.kt
@@ -18,7 +18,7 @@ data class StartContext(
     val circuitCanvas: Canvas,
     val simulationEnabled: CheckMenuItem,
     val clickMode: ToggleButton,
-    val scaleFactorInput: TextField,
+    val scaleFactorSlider: Slider,
     val bitSizeSelect: ComboBox<Int>,
     val buttonTabPane: Accordion,
     val buttonsToggleGroup: ToggleGroup,

--- a/src/main/kotlin/com/ra4king/circuitsim/gui/CircuitSim.kt
+++ b/src/main/kotlin/com/ra4king/circuitsim/gui/CircuitSim.kt
@@ -114,13 +114,11 @@ class CircuitSim @JvmOverloads constructor(val openWindow: Boolean, val init: Bo
         set(value) {
             if (!clickedDirectly) clickMode.isSelected = value
         }
-    val scaleFactorInput get() = startContext.scaleFactorInput
+    val scaleFactorSlider get() = startContext.scaleFactorSlider
     var scaleFactor
-        get() = scaleFactorInput.textFormatter.value as Double
+        get() = scaleFactorSlider.value
         set(value) {
-            @Suppress("UNCHECKED_CAST")
-            val formatter = scaleFactorInput.textFormatter as TextFormatter<Double>
-            formatter.value = clampScaleFactor(value)
+            scaleFactorSlider.value = clampScaleFactor(value)
         }
     val scaleFactorInverted get() = 1.0 / scaleFactor
     val bitSizeSelect get() = startContext.bitSizeSelect
@@ -1337,7 +1335,7 @@ class CircuitSim @JvmOverloads constructor(val openWindow: Boolean, val init: Bo
             canvas,
             CheckMenuItem("Simulation Enabled"),
             ToggleButton("Click Mode (Shift)"),
-            TextField(),
+            Slider(),
             ComboBox(),
             Accordion(),
             ToggleGroup(),
@@ -1369,22 +1367,13 @@ class CircuitSim @JvmOverloads constructor(val openWindow: Boolean, val init: Bo
             modifiedSelection(selectedComponent)
         }
 
-        scaleFactorInput.maxWidth = 80.0
-        scaleFactorInput.prefWidth = 80.0
-        scaleFactorInput.textFormatter = TextFormatter<Double>(object : StringConverter<Double>() {
-            override fun toString(value: Double?): String? {
-                val df = DecimalFormat("0.0#")
-                df.roundingMode = RoundingMode.HALF_UP
-                return value?.let { df.format(it) } ?: ""
-            }
-
-            override fun fromString(string: String?): Double {
-                return if (string?.isBlank() ?: return 1.0) 1.0
-                else clampScaleFactor(string.toDouble())
-            }
-
-        }, 1.0) { if (it.controlNewText.matches("\\d*(?:\\.\\d*)?".toRegex())) it else null }
-        scaleFactorInput.textFormatter.valueProperty().addListener { _, _, _ -> needsRepaint = true }
+        scaleFactorSlider.min = 0.25
+        scaleFactorSlider.max = 4.0
+        scaleFactorSlider.value = 1.0
+        scaleFactorSlider.isShowTickLabels = false
+        scaleFactorSlider.isShowTickMarks = false
+        scaleFactorSlider.maxWidth = 120.0
+        scaleFactorSlider.valueProperty().addListener { _, _, _ -> needsRepaint = true }
 
         componentLabel.font = getFont(16)
         canvasScrollPane.isFocusTraversable = true
@@ -1790,12 +1779,19 @@ class CircuitSim @JvmOverloads constructor(val openWindow: Boolean, val init: Bo
         bitSizeSelect.styleClass.add("bit-size-dropdown")
         val bitSize = HBox(bitSizeLabel, bitSizeSelect)
         bitSize.styleClass.add("bit-size-box")
+        bitSize.setOnMouseClicked { bitSizeSelect.show() }
+        bitSizeSelect.setOnShowing {
+            bitSize.styleClass.add("showing-dropdown")
+        }
+        bitSizeSelect.setOnHidden {
+            bitSize.styleClass.remove("showing-dropdown")
+        }
         toolbar.items.addAll(
             clickMode, Separator(Orientation.VERTICAL),
             inputPinButton, outputPinButton, andButton, orButton,
             notButton, xorButton, tunnelButton, textButton,
             Separator(Orientation.VERTICAL), bitSize,
-            blank, Label("Scale:"), scaleFactorInput
+            blank, Label("Scale:"), scaleFactorSlider
         )
 
         VBox.setVgrow(canvasPropsSplit, Priority.ALWAYS)

--- a/src/main/kotlin/com/ra4king/circuitsim/gui/CircuitSim.kt
+++ b/src/main/kotlin/com/ra4king/circuitsim/gui/CircuitSim.kt
@@ -398,7 +398,7 @@ class CircuitSim @JvmOverloads constructor(val openWindow: Boolean, val init: Bo
         button.minHeight = 30.0
         button.maxWidth = Double.Companion.MAX_VALUE
         button.onAction = EventHandler { modifiedSelection(if (button.isSelected) componentInfo else null) }
-        button.styleClass.add("new-component")
+        button.styleClass.add("new-component-btn")
         GridPane.setHgrow(button, Priority.ALWAYS)
         return button
     }
@@ -443,7 +443,7 @@ class CircuitSim @JvmOverloads constructor(val openWindow: Boolean, val init: Bo
                 component.connections.forEach { it.paint(icon.graphicsContext2D, null) }
 
                 val toggleButton = ToggleButton(pair.first.name.second, icon)
-                toggleButton.styleClass.add("new-component")
+                toggleButton.styleClass.add("new-component-btn")
                 toggleButton.alignment = Pos.CENTER_LEFT
                 toggleButton.toggleGroup = buttonsToggleGroup
                 toggleButton.minHeight = 30.0

--- a/src/main/resources/styles/style.css
+++ b/src/main/resources/styles/style.css
@@ -30,7 +30,7 @@
      /* Dropdown list item palette  */
     -csim-dropdown-btn-color-base: #EEEEEE;
     -csim-dropdown-btn-color-hover: derive(-csim-dropdown-btn-color-base, -15%);
-    -csim-dropdown-btn-color-pressed: #CCCCCC;
+    -csim-dropdown-btn-color-pressed: #00692c;
     -csim-dropdown-btn-color-pressed-hover: derive(-csim-dropdown-btn-color-pressed, -10%);
     -csim-dropdown-btn-color-border: #BBBBBB;
 

--- a/src/main/resources/styles/style.css
+++ b/src/main/resources/styles/style.css
@@ -1,48 +1,85 @@
 /* style.css */
 .root {
+    /* App background color */
     -fx-background-color: #f0f0f0;
+
+    /* The background color of a pressable button. */
+    -csim-btn-color: -csim-btn-color-base;
+    /* The text color of a pressable button. */
+    -csim-btn-text-color: white;
+    /* Button color palette */
+    -csim-btn-color-base: #00692c;
+    -csim-btn-color-hover: derive(-csim-btn-color-base, 25%);
+    -csim-btn-color-pressed: derive(-csim-btn-color-base, 50%);
+
+    /* The background color of a toggleable button. */
+    -csim-toggle-btn-color: -csim-toggle-btn-color-base;
+    /* The text color of a toggleable button. */
+    -csim-toggle-btn-text-color: ladder(-csim-toggle-btn-color, white 49%, black 50%);
+    -csim-toggle-btn-border-color: derive(-csim-toggle-btn-color, -25%);
+    /* Toggle button color palette */
+    -csim-toggle-btn-color-base: #DDDDDD;
+    -csim-toggle-btn-color-hover: derive(-csim-toggle-btn-color-base, 33%);
+    -csim-toggle-btn-color-pressed: #01ad49;
+    -csim-toggle-btn-color-pressed-hover: derive(-csim-toggle-btn-color-pressed, 33%);
+
+    /* The background color of a dropdown list item. */
+    -csim-dropdown-btn-color: -csim-dropdown-btn-color-base;
+    /* The text color of a dropdown list item. */
+    -csim-dropdown-btn-text-color: ladder(-csim-dropdown-btn-color, white 49%, black 50%);
+     /* Dropdown list item palette  */
+     -csim-dropdown-btn-color-base: #D0F8FF;
+     -csim-dropdown-btn-color-hover: derive(-csim-dropdown-btn-color-base, 33%);
+     -csim-dropdown-btn-color-pressed: #0066FF;
+     -csim-dropdown-btn-color-pressed-hover: derive(-csim-dropdown-btn-color-pressed, 33%);
+
 }
 
+/* Buttons */
 .button {
-    -fx-background-color: #006a23;
+    -fx-background-color: -csim-btn-color;
+    -fx-text-fill: -csim-btn-text-color;
     -fx-background-radius: 8;
-    -fx-text-fill: white;
     -fx-font-size: 14px;
 }
 .button:hover {
-    -fx-background-color: #003a00;
+    -csim-btn-color: -csim-btn-color-hover;
+}
+.button:armed {
+    -csim-btn-color: -csim-btn-color-pressed;
 }
 
 .toggle-button {
-    -fx-background-color: #DDDDDD;
-    -fx-text-fill: black;
+    -fx-background-color: -csim-toggle-btn-border-color, -csim-toggle-btn-color;
+    -fx-background-insets: 0, 1;
+    -fx-text-fill: -csim-toggle-btn-text-color;
 }
 .toggle-button:hover {
-    -fx-background-color: #CCF0CC;
+    -csim-toggle-btn-color: -csim-toggle-btn-color-hover;
 }
 .toggle-button:selected {
-    -fx-background-color: #AAAAAA;
+    -csim-toggle-btn-color: -csim-toggle-btn-color-pressed;
 }
 .toggle-button:hover:selected {
-    -fx-background-color: #99C099;
+    -csim-toggle-btn-color: -csim-toggle-btn-color-pressed-hover;
 }
 
-.new-component {
-    -fx-text-fill: #000;
+/* Button for creating new components */
+.new-component-btn {
     -fx-min-height: 48px;
     -fx-max-width: 200px;
     -fx-padding: 8 8 8 8;
     -fx-background-radius: 8;
 }
 
-.props-menu {
-    -fx-background-color: #396;
-}
+/* Properties panel */
 
+/* Properties panel: Content background */
 .props-table {
     -fx-background-color: #FFF;
 }
 
+/* Properties panel: Label column */
 .props-menu-label {
     -fx-background-color: transparent;
     -fx-text-fill: black;
@@ -50,31 +87,32 @@
     -fx-padding: 8 8 8 16;
 }
 
+/* Properties panel: Value column */
 .props-menu-value {
     -fx-background-color: transparent;
-    -fx-text-fill: #000;
+    -fx-text-fill: black;
     -fx-min-width: 250;
     -fx-padding: 8 8 8 0;
 }
 
-.property-list-validator {
-}
-
+/* Property list buttons */
 .property-list-validator-button {
-    -fx-background-color: #D0F8FF;
+    -fx-background-color: -csim-dropdown-btn-color;
+    -fx-text-fill: -csim-dropdown-btn-text-color;
     -fx-min-width: 36px;
 }
 .property-list-validator-button:hover {
-    -fx-background-color: #75b1ff;
+    -csim-dropdown-btn-color: -csim-dropdown-btn-color-hover;
 }
 .property-list-validator-button:selected {
-    -fx-background-color: #06F;
-    -fx-text-fill: white;
+    -csim-dropdown-btn-color: -csim-dropdown-btn-color-pressed;
 }
 .property-list-validator-button:hover:selected {
-    -fx-background-color: #06F;
-    -fx-text-fill: white;
+    -csim-dropdown-btn-color: -csim-dropdown-btn-color-pressed-hover;
 }
+
+/* TODO (for everything below this comment) */
+/* Reduce number of custom colors */
 
 .property-list-validator-dropdown {
     -fx-background-color: #AEE;

--- a/src/main/resources/styles/style.css
+++ b/src/main/resources/styles/style.css
@@ -20,7 +20,7 @@
     /* Toggle button color palette */
     -csim-toggle-btn-color-base: #DDDDDD;
     -csim-toggle-btn-color-hover: derive(-csim-toggle-btn-color-base, 33%);
-    -csim-toggle-btn-color-pressed: #01ad49;
+    -csim-toggle-btn-color-pressed: #adadad;
     -csim-toggle-btn-color-pressed-hover: derive(-csim-toggle-btn-color-pressed, 33%);
 
     /* The background color of a dropdown list item. */
@@ -28,11 +28,62 @@
     /* The text color of a dropdown list item. */
     -csim-dropdown-btn-text-color: ladder(-csim-dropdown-btn-color, white 49%, black 50%);
      /* Dropdown list item palette  */
-     -csim-dropdown-btn-color-base: #D0F8FF;
-     -csim-dropdown-btn-color-hover: derive(-csim-dropdown-btn-color-base, 33%);
-     -csim-dropdown-btn-color-pressed: #0066FF;
-     -csim-dropdown-btn-color-pressed-hover: derive(-csim-dropdown-btn-color-pressed, 33%);
+    -csim-dropdown-btn-color-base: #EEEEEE;
+    -csim-dropdown-btn-color-hover: derive(-csim-dropdown-btn-color-base, -15%);
+    -csim-dropdown-btn-color-pressed: #CCCCCC;
+    -csim-dropdown-btn-color-pressed-hover: derive(-csim-dropdown-btn-color-pressed, -10%);
+    -csim-dropdown-btn-color-border: #BBBBBB;
 
+    /* The background color of a tab button */
+    -csim-tab-btn-pane-color-base: #f8f9fa;
+
+    /* New component palette */
+    -csim-component-text-color: #343a40;
+    -csim-component-text-base: #EEE;
+    -csim-component-expanded-base: #F4F4F4;
+    -csim-component-arrow-base: #6c757d;
+
+    /* Text Field palette */
+    -csim-text-field-color: #333333;
+    -csim-text-field-prompt-color: #888888;
+
+    /* Tab Pane palette */
+    -csim-tab-pane-color-base: #f9f9f9;
+    -csim-tab-pane-color-border: #cccccc;
+    -csim-tab-pane-color-hover: #d8d8d8;
+    -csim-tab-pane-color-selected: #dddddd;
+    -csim-tab-header-color-base: #eaeaea;
+    -csim-tab-text-color: #333333;
+    -csim-tab-text-color-selected: black;
+
+    /* Bitsize Content palette */
+    -csim-bit-size-color-base: #DDDDDD;
+    -csim-bit-size-color-border: #BBBBBB;
+
+    /* Slider thumb palette */
+    -csim-thumb-base:    -csim-bit-size-color-base;
+    -csim-thumb-border:  -csim-bit-size-color-border;
+    -csim-thumb-hover:   derive(-csim-thumb-base, 25%);
+    -csim-thumb-pressed: derive(-csim-thumb-base, 50%);
+
+    /* Level Indicator palette */
+    -csim-level-border-base: #aaaaaa;
+    -csim-top-level-border-indicator: #07c;
+    -csim-nested-level-border-indicator: #c22;
+
+    /* Tilted Pane palette */
+    -csim-tilted-pane-base: #f2f2f2;
+    -csim-tilted-pane-open-base: #f9fafb;
+    -csim-tilted-pane-hover: #dddddd;
+    -csim-tilted-pane-title-base: white;
+    -csim-tilted-pane-title-border: #dddddd;
+
+    /* Color Picker Palette */
+    -csim-color-picker-base: #aee;
+    -csim-color-picker-border: #8cc;
+
+    /* The text color of input during edit */
+    -csim-edit-text-color: -csim-top-level-border-indicator;
 }
 
 /* Buttons */
@@ -76,7 +127,7 @@
 
 /* Properties panel: Content background */
 .props-table {
-    -fx-background-color: #FFF;
+    -fx-background-color: white;
 }
 
 /* Properties panel: Label column */
@@ -111,16 +162,12 @@
     -csim-dropdown-btn-color: -csim-dropdown-btn-color-pressed-hover;
 }
 
-/* TODO (for everything below this comment) */
-/* Reduce number of custom colors */
-
 .property-list-validator-dropdown {
-    -fx-background-color: #AEE;
+    -fx-background-color: -csim-dropdown-btn-color;
     -fx-background-radius: 8 8 8 8;
     -fx-border-width: 1 1 1 1;
-    -fx-border-color: #8CC;
+    -fx-border-color: -csim-dropdown-btn-color-border;
     -fx-border-radius: 8 8 8 8;
-
 }
 
 .button-top-left {
@@ -148,8 +195,7 @@
 }
 
 .button-tab-pane {
-
-    -fx-background-color: #f8f9fa;
+    -fx-background-color: -csim-tab-btn-pane-color-base;
     -fx-border-color: transparent;
     -fx-padding: 10;
 }
@@ -164,21 +210,21 @@
 }
 
 .new-component-section > .title {
-    -fx-background-color: #ffffff;
-    -fx-text-fill: #343a40;
+    -fx-background-color: white;
+    -fx-text-fill: -csim-component-text-color;
     -fx-font-size: 15px;
     -fx-font-weight: 600;
     -fx-padding: 10 14;
 }
 
 .new-component-section:expanded > .title {
-    -fx-background-color: #F4F4F4;
+    -fx-background-color: -csim-component-expanded-base;
 }
 
 .new-component-section > *.content {
     -fx-padding: 4 4 0 4;
-    -fx-background-color: #F4F4F4;
-    -fx-border-color: #F4F4F4;
+    -fx-background-color: -csim-component-expanded-base;
+    -fx-border-color: -csim-component-expanded-base;
 }
 
 .new-component-section > .content {
@@ -191,25 +237,31 @@
 
 .new-component-section > .title > .arrow-button > .arrow {
     -fx-shape: "M 0 0 L 6 6 L 12 0 Z";
-    -fx-background-color: #6c757d;
+    -fx-background-color: -csim-component-arrow-base;
+    -fx-focus-color: transparent;
     -fx-scale-x: 0.8;
     -fx-scale-y: 0.8;
 }
 
 .text-field {
-    -fx-background-color: #EEE;
+    -fx-background-color: -csim-component-text-base;
     -fx-background-radius: 8;
     -fx-border-color: transparent;
     -fx-border-radius: 8;
+    -fx-border-width: 2;
     -fx-padding: 8 12;
     -fx-font-size: 14px;
-    -fx-text-fill: #333333;
-    -fx-prompt-text-fill: #888888;
-    -fx-focus-color: transparent; /* suppress default glow */
+    -fx-text-fill: -csim-text-field-color;
+    -fx-prompt-text-fill: -csim-text-field-prompt-color;
+    -fx-focus-color: transparent;
     -fx-faint-focus-color: transparent;
     -fx-effect: dropshadow(one-pass-box, rgba(0,0,0,0.05), 2, 0, 0, 1);
     -fx-transition: all 0.3s ease-in-out;
     -fx-max-width: 224px;
+}
+
+.text-field:focused {
+    -fx-border-color: -csim-edit-text-color;
 }
 
 .global-bit-size {
@@ -227,17 +279,17 @@
 
 /* Style the entire TabPane */
 .tab-pane {
-    -fx-background-color: #f9f9f9;
-    -fx-border-color: #cccccc;
+    -fx-background-color: -csim-tab-pane-color-base;
+    -fx-border-color: -csim-tab-pane-color-border;
     -fx-border-width: 1;
     -fx-tab-min-width: 64px;
 }
 
 /* Tab header area */
 .tab-pane > .tab-header-area {
-    -fx-background-color: #eaeaea;
+    -fx-background-color: -csim-tab-header-color-base;
     -fx-padding: 8px 8px 0 8px;
-    -fx-border-color: #cccccc;
+    -fx-border-color: -csim-tab-pane-color-border;
     -fx-border-width: 0 0 1 0;
 }
 
@@ -245,29 +297,38 @@
 .tab-pane .tab {
     -fx-background-insets: 0;
     -fx-padding: 8 16 8 16;
-    -fx-background-color: #CCC;
-    -fx-text-fill: #333;
+    -fx-background-color: -csim-tab-pane-color-border;
+    -fx-text-fill: -csim-tab-text-color;
     -fx-font-size: 14px;
 }
 
 /* Hovered tab */
 .tab-pane .tab:hover {
-    -fx-background-color: #D8D8D8;
+    -fx-background-color: -csim-tab-pane-color-hover;
 }
 
 /* Selected tab */
 .tab-pane .tab:selected {
-    -fx-background-color: #DDD;
-    -fx-text-fill: #000000;
-    -fx-border-width: 1 1 5 1;
+    -fx-background-color: -csim-tab-pane-color-selected;
+    -fx-text-fill: black;
+    -fx-focus-color: transparent;
+    -fx-faint-focus-color: transparent;
 }
 
 .top-level-indicator {
-    -fx-border-color: #AAA #AAA #07C #AAA;
+    -fx-border-color:
+        -csim-level-border-base
+        -csim-level-border-base
+        -csim-top-level-border-indicator
+        -csim-level-border-base;
 }
 
 .nested-state-indicator {
-    -fx-border-color: #AAA #AAA #C22 #AAA;
+    -fx-border-color:
+        -csim-level-border-base
+        -csim-level-border-base
+        -csim-nested-level-border-indicator
+        -csim-level-border-base;
 }
 
 /* Content area */
@@ -276,32 +337,68 @@
 
 .tab-pane .tab {
     -fx-background-radius: 8 8 0 0;
-    -fx-border-radius: 8 8 0 0;;
+    -fx-border-radius: 8 8 0 0;
 }
 .tab-pane .tab:selected {
 }
 
-
 .bit-size-label {
-    -fx-background-color: #DDD;
-    -fx-background-radius: 8 0 0 8;
-    -fx-border-width: 1 0 1 1;
-    -fx-border-color: #BBB;
-    -fx-border-radius: 8 0 0 8;
-    -fx-padding: 8;
+    -fx-background-color: transparent;
+    -fx-background-radius: 0;
+    -fx-border-color: transparent;
+    -fx-border-radius: 0;
+    -fx-padding: 4;
 }
 
 .bit-size-dropdown {
-    -fx-background-color: #DDD;
-    -fx-background-radius: 0 8 8 0;
-    -fx-border-width: 1 1 1 0;
-    -fx-border-color: #BBB;
-    -fx-border-radius: 0 8 8 0;
+    -fx-background-color: transparent;
+    -fx-background-radius: 0;
+    -fx-border-width: 0;
+    -fx-border-color: transparent;
+    -fx-border-radius: 0;
     -fx-padding: 4;
 }
 
 .bit-size-box {
     -fx-alignment: center;
+    -fx-background-color: -csim-bit-size-color-base;
+    -fx-background-radius: 8;
+    -fx-border-width: 1;
+    -fx-border-color: -csim-bit-size-color-border;
+    -fx-border-radius: 8;
+    -fx-pref-height: 25;
+    -fx-max-height: 25;
+}
+
+.bit-size-box:hover {
+    -fx-background-color: derive(-csim-bit-size-color-base, 20%);
+}
+
+.bit-size-box:pressed {
+    -fx-border-color: -csim-edit-text-color;
+}
+
+.bit-size-box:focused {
+    -fx-border-color: -csim-edit-text-color;
+}
+
+.bit-size-box.showing-dropdown {
+    -fx-border-color: -csim-edit-text-color;
+}
+
+/* Scale slider thumb */
+.slider .thumb {
+    -fx-background-color: -csim-thumb-border, -csim-thumb-base;
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 8, 7; /* optional rounding */
+}
+
+.slider .thumb:hover {
+    -fx-background-color: -csim-thumb-border, -csim-thumb-hover;
+}
+
+.slider .thumb:pressed {
+    -fx-background-color: -csim-thumb-border, -csim-thumb-pressed;
 }
 
 .accordion {
@@ -312,8 +409,8 @@
 
 /* TitledPane base */
 .titled-pane {
-    -fx-background-color: #f2f2f2; /* light gray bg */
-    -fx-border-color: #f2f2f2;     /* soft border */
+    -fx-background-color: -csim-tilted-pane-base;
+    -fx-border-color: -csim-tilted-pane-base;
     -fx-padding: 0;
 }
 
@@ -324,18 +421,25 @@
     -fx-padding: 12px 16px;
     -fx-font-size: 14px;
     -fx-font-weight: 500;
-    -fx-border-color: #DDD;
+    -fx-border-color: -csim-tilted-pane-hover;
     -fx-border-width: 0 0 2 0;
 }
 
 /* Hover effect */
 .titled-pane > .title:hover {
-    -fx-background-color: #DDD; /* Tailwind gray-100 */
+    -fx-background-color: -csim-tilted-pane-hover;
+}
+
+/* Prevent movement during accordian animation */
+.titled-pane > .content {
+    -fx-padding: 12px 16px;
+    -fx-background-color: -csim-tilted-pane-open-base;
+    -fx-smooth: false;
 }
 
 /* Open panel */
 .titled-pane:expanded > .content {
-    -fx-background-color: #f9fafb;
+    -fx-background-color: -csim-tilted-pane-open-base;
     -fx-padding: 12px 16px;
 }
 
@@ -349,10 +453,9 @@
 }
 
 .color-picker {
-    -fx-background-color: #AEE;
+    -fx-background-color: -csim-color-picker-base;
     -fx-background-radius: 8 8 8 8;
     -fx-border-width: 1 1 1 1;
-    -fx-border-color: #8CC;
+    -fx-border-color: -csim-color-picker-border;
     -fx-border-radius: 8 8 8 8;
-
 }

--- a/src/main/resources/styles/style.css
+++ b/src/main/resources/styles/style.css
@@ -311,6 +311,7 @@
 .tab-pane .tab:selected {
     -fx-background-color: -csim-tab-pane-color-selected;
     -fx-text-fill: black;
+    -fx-border-width: 1 1 5 1;
     -fx-focus-color: transparent;
     -fx-faint-focus-color: transparent;
 }


### PR DESCRIPTION
This PR aims to improve the UI introduced in #18. 

References:
- JavaFX CSS docs [here](https://openjfx.io/javadoc/24/javafx.graphics/javafx/scene/doc-files/cssref.html)
- Modena stylesheet source code [here](<https://github.com/openjdk/jfx/blob/master/modules/javafx.controls/src/main/resources/com/sun/javafx/scene/control/skin/modena/modena.css>) for understanding which CSS selectors need to be modified

This PR aims to do the following:
- [x] Refactor the CSS to use palette instead of fixed hex values in CSS selectors
- [X] Improve consistency between buttons (completed: created button and toggle button styling)
- [X] Improve readability between buttons (allowing users to discern between hover, activated, activated+hover again)
- [x] Accordion resizes and moves buttons around on collapse
- [x] Tabs have a strange UI when clicked
- [x] Tab text moves up when selected 
- [x] Add indication to inputs when clicked into

Other possibilities include:
- Using and tweaking AtlantaFX (<https://github.com/mkpaz/atlantafx>)
