### PR TITLE
Reintroduces UI changes introduced from 1.11.x

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitBoard.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitBoard.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -24,6 +25,8 @@ import com.ra4king.circuitsim.simulator.CircuitState;
 import com.ra4king.circuitsim.simulator.SimulationException;
 import com.ra4king.circuitsim.simulator.Simulator;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
 import javafx.util.Pair;
@@ -61,6 +64,8 @@ public class CircuitBoard {
 	
 	private final EditHistory editHistory;
 	
+	private final BooleanProperty isTopLevel;
+
 	private static class MoveComputeResult {
 		final Set<Wire> wiresToAdd;
 		final Set<Wire> wiresToRemove;
@@ -85,6 +90,8 @@ public class CircuitBoard {
 		links = new HashSet<>();
 		
 		connectionsMap = new HashMap<>();
+
+		this.isTopLevel = new SimpleBooleanProperty(true);
 	}
 	
 	public String getName() {
@@ -136,8 +143,13 @@ public class CircuitBoard {
 		}
 		
 		currentState = state;
+		this.isTopLevel.setValue(currentState == circuit.getTopLevelState());
 	}
 	
+	public void onTopLevelChange(Consumer<? super Boolean> callback) {
+		this.isTopLevel.subscribe(callback);
+	}
+
 	public Set<ComponentPeer<?>> getComponents() {
 		return components;
 	}

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -1905,6 +1905,11 @@ public class CircuitSim extends Application {
 			circuitManagers.put(canvasTab.getText(), new Pair<>(createSubcircuitLauncherInfo(revisedName), circuitManager));
 			canvasTabPane.getTabs().add(canvasTab);
 			
+			// Update tab status when top level status changes
+			circuitManager.getCircuitBoard().onTopLevelChange(tl -> {
+				canvasTab.getStyleClass().removeAll("top-level-indicator", "nested-state-indicator");
+				canvasTab.getStyleClass().add(tl ? "top-level-indicator" : "nested-state-indicator");
+			});
 			refreshCircuitsTab();
 			
 			editHistory.addAction(EditAction.CREATE_CIRCUIT,
@@ -2732,6 +2737,8 @@ public class CircuitSim extends Application {
 		scene = new Scene(new VBox(menuBar, toolBar, canvasPropsSplit));
 		scene.setCursor(Cursor.DEFAULT);
 		
+		scene.getStylesheets().add(getClass().getResource("/styles/style.css").toExternalForm());
+
 		updateTitle();
 		stage.setScene(scene);
 		stage.sizeToScene();

--- a/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/CircuitSim.java
@@ -702,11 +702,7 @@ public class CircuitSim extends Application {
 				
 				GridPane.setHgrow(name, Priority.ALWAYS);
 				name.setMaxWidth(Double.MAX_VALUE);
-				name.setMinHeight(30);
-				name.setBackground(new Background(new BackgroundFill((size / 2) % 2 == 0 ? Color.LIGHTGRAY :
-				                                                     Color.WHITE,
-				                                                     null,
-				                                                     null)));
+				name.getStyleClass().add("props-menu-label");
 				
 				Node node = property.validator.createGui(stage, property.value, newValue -> Platform.runLater(() -> {
 					Properties newProperties = new Properties(properties);
@@ -717,10 +713,7 @@ public class CircuitSim extends Application {
 				if (node != null) {
 					StackPane valuePane = new StackPane(node);
 					StackPane.setAlignment(node, Pos.CENTER_LEFT);
-					valuePane.setBackground(new Background(new BackgroundFill((size / 2) % 2 == 0 ? Color.LIGHTGRAY :
-					                                                          Color.WHITE,
-					                                                          null,
-					                                                          null)));
+					valuePane.getStyleClass().add("props-menu-value");
 					GridPane.setHgrow(valuePane, Priority.ALWAYS);
 					GridPane.setVgrow(valuePane, Priority.ALWAYS);
 					propertiesTable.addRow(size, name, valuePane);
@@ -2634,9 +2627,11 @@ public class CircuitSim extends Application {
 			new MenuBar(fileMenu, editMenu, viewMenu, circuitsMenu, simulationMenu, helpMenu);
 		menuBar.setUseSystemMenuBar(true);
 		
+		propertiesTable.getStyleClass().add("props-table");
 		ScrollPane propertiesScrollPane = new ScrollPane(propertiesTable);
 		propertiesScrollPane.setFitToWidth(true);
 		
+		propertiesScrollPane.getStyleClass().add("props-menu");
 		VBox propertiesBox = new VBox(componentLabel, propertiesScrollPane);
 		propertiesBox.setAlignment(Pos.TOP_CENTER);
 		VBox.setVgrow(propertiesScrollPane, Priority.ALWAYS);

--- a/src/main/java/com/ra4king/circuitsim/gui/properties/PropertyListValidator.java
+++ b/src/main/java/com/ra4king/circuitsim/gui/properties/PropertyListValidator.java
@@ -1,8 +1,6 @@
 package com.ra4king.circuitsim.gui.properties;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -10,7 +8,12 @@ import java.util.stream.Collectors;
 import com.ra4king.circuitsim.gui.Properties.PropertyValidator;
 
 import javafx.scene.Node;
+import javafx.collections.ObservableList;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
 /**
@@ -73,14 +76,100 @@ public class PropertyListValidator<T> implements PropertyValidator<T> {
 		return value == null ? "" : toString.apply(value);
 	}
 	
+	@SuppressWarnings("unchecked")
 	@Override
 	public Node createGui(Stage stage, T value, Consumer<T> onAction) {
-		ComboBox<String> valueList = new ComboBox<>();
-		
-		for (T t : validValues) {
-			valueList.getItems().add(toString.apply(t));
+		int size = validValues.size();
+		if (size > 33) return createTextField(value, onAction);
+		if (value instanceof Integer) {
+			boolean none = validValues.contains(-1);
+			boolean zero = validValues.contains(0);
+			if (none) {
+				if (size > 9)
+					return createDropdown(value, onAction);
+				else
+					return createHorizontalSelect(value, onAction);
+			}
+			VBox vbox = new VBox();
+			for (int i = 0; i < 4; i++) {
+				HBox hbox = new HBox();
+				for (int j = 0; j < 8; j++) {
+					final int n = i * 8 + j + (zero ? 0 : 1);
+					if (!validValues.contains(n)) continue;
+					String s = Integer.toString(n);
+					ToggleButton button = new ToggleButton(s);
+
+					ObservableList<String> style = button.getStyleClass();
+					style.add("property-list-validator-button");
+
+					if (size == 1) style.add("round-all");
+					else if (size < 9) {
+						if (j == 0) style.add("round-left");
+						else if (j == 7) style.add("round-right");
+					} else {
+						if (i == 0 && j == 0) style.add("round-top-left");
+						else if (i == 0 && j == 7) style.add("round-top-right");
+						else if (i == (size - 1) / 8 && j == 0) style.add("round-bottom-left");
+						else if (i == (size - 1) / 8 && j == 7) style.add("round-bottom-right");
+					}
+
+					button.setSelected(toString(value).equals(s));
+					button.setOnAction(event -> {
+						try {
+							// Type warning suppressed here.
+							// value is known to be an Integer at this point 
+							// (due to instanceof check above)
+							onAction.accept((T) (Integer) n);
+						} catch (Exception e) {
+							e.printStackTrace();
+						}
+						hbox.getChildren().forEach(node -> {
+							if (node instanceof ToggleButton toggleButton) {
+								toggleButton.setSelected(toggleButton == button);
+							}
+						});
+					});
+					hbox.getChildren().add(button);
+
+				}
+				vbox.getChildren().add(hbox);
+			}
+			return vbox;
 		}
-		
+		int width = 0;
+        for (T validValue : validValues) {
+            width += validValue.toString().length() + 2;
+        }
+		return width > 36 ? createDropdown(value, onAction) : createHorizontalSelect(value, onAction);
+	}
+
+	TextField createTextField(T value, Consumer<T> onAction) {
+		TextField textField = new TextField();
+		textField.getStyleClass().add("property-list-validator-textfield");
+		textField.setText(toString(value));
+		textField.focusedProperty().addListener((observable, oldValue, newValue) -> {
+			if (!newValue) {
+				try {
+					onAction.accept(parse(textField.getText()));
+				} catch (Exception exc) {
+					exc.printStackTrace();
+				}
+			}
+		});
+		return textField;
+	}
+
+	ComboBox<String> createDropdown(T value, Consumer<T> onAction) {
+		HashSet<String> commonValues = new HashSet<>(Arrays.asList("1", "2", "4", "8", "16", "32"));
+		ComboBox<String> valueList = new ComboBox<>();
+
+		for (T t : validValues) {
+			if (!commonValues.contains(t))
+				valueList.getItems().add(toString.apply(t));
+		}
+
+		valueList.getStyleClass().add("property-list-validator-dropdown");
+
 		valueList.setValue(toString(value));
 		valueList.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
 			if (!newValue.equals(oldValue)) {
@@ -91,7 +180,33 @@ public class PropertyListValidator<T> implements PropertyValidator<T> {
 				}
 			}
 		});
-		
 		return valueList;
+	}
+
+	Node createHorizontalSelect(T value, Consumer<T> onAction) {
+		ArrayList<ToggleButton> buttons = new ArrayList<>();
+		String selected = toString(value);
+		for (int i = 0; i < validValues.size(); i++) {
+			T t = validValues.get(i);
+			String text = toString.apply(t);
+			ToggleButton button = new ToggleButton(text);
+			buttons.add(button);
+			button.setSelected(text.equals(selected));
+			button.setOnAction(event -> {
+				try {
+					onAction.accept(t);
+				} catch (Exception exc) {
+					exc.printStackTrace();
+				}
+				buttons.forEach(node -> {
+					ToggleButton toggleButton = (ToggleButton) node;
+					toggleButton.setSelected(toggleButton == button);
+				});
+			});
+			button.getStyleClass().add("property-list-validator-button");
+			if (i == 0 && validValues.size() > 1) button.getStyleClass().add("button-left");
+			else if (i == validValues.size() - 1 && validValues.size() > 1) button.getStyleClass().add("button-right");
+		}
+		return new HBox(buttons.toArray(new ToggleButton[0]));
 	}
 }

--- a/src/main/resources/styles/style.css
+++ b/src/main/resources/styles/style.css
@@ -1,0 +1,461 @@
+/* style.css */
+.root {
+    /* App background color */
+    -fx-background-color: #f0f0f0;
+
+    /* The background color of a pressable button. */
+    -csim-btn-color: -csim-btn-color-base;
+    /* The text color of a pressable button. */
+    -csim-btn-text-color: white;
+    /* Button color palette */
+    -csim-btn-color-base: #00692c;
+    -csim-btn-color-hover: derive(-csim-btn-color-base, 25%);
+    -csim-btn-color-pressed: derive(-csim-btn-color-base, 50%);
+
+    /* The background color of a toggleable button. */
+    -csim-toggle-btn-color: -csim-toggle-btn-color-base;
+    /* The text color of a toggleable button. */
+    -csim-toggle-btn-text-color: ladder(-csim-toggle-btn-color, white 49%, black 50%);
+    -csim-toggle-btn-border-color: derive(-csim-toggle-btn-color, -25%);
+    /* Toggle button color palette */
+    -csim-toggle-btn-color-base: #DDDDDD;
+    -csim-toggle-btn-color-hover: derive(-csim-toggle-btn-color-base, 33%);
+    -csim-toggle-btn-color-pressed: #adadad;
+    -csim-toggle-btn-color-pressed-hover: derive(-csim-toggle-btn-color-pressed, 33%);
+
+    /* The background color of a dropdown list item. */
+    -csim-dropdown-btn-color: -csim-dropdown-btn-color-base;
+    /* The text color of a dropdown list item. */
+    -csim-dropdown-btn-text-color: ladder(-csim-dropdown-btn-color, white 49%, black 50%);
+     /* Dropdown list item palette  */
+    -csim-dropdown-btn-color-base: #EEEEEE;
+    -csim-dropdown-btn-color-hover: derive(-csim-dropdown-btn-color-base, -15%);
+    -csim-dropdown-btn-color-pressed: #00692c;
+    -csim-dropdown-btn-color-pressed-hover: derive(-csim-dropdown-btn-color-pressed, -10%);
+    -csim-dropdown-btn-color-border: #BBBBBB;
+
+    /* The background color of a tab button */
+    -csim-tab-btn-pane-color-base: #f8f9fa;
+
+    /* New component palette */
+    -csim-component-text-color: #343a40;
+    -csim-component-text-base: #EEE;
+    -csim-component-expanded-base: #F4F4F4;
+    -csim-component-arrow-base: #6c757d;
+
+    /* Text Field palette */
+    -csim-text-field-color: #333333;
+    -csim-text-field-prompt-color: #888888;
+
+    /* Tab Pane palette */
+    -csim-tab-pane-color-base: #f9f9f9;
+    -csim-tab-pane-color-border: #cccccc;
+    -csim-tab-pane-color-hover: #d8d8d8;
+    -csim-tab-pane-color-selected: #dddddd;
+    -csim-tab-header-color-base: #eaeaea;
+    -csim-tab-text-color: #333333;
+    -csim-tab-text-color-selected: black;
+
+    /* Bitsize Content palette */
+    -csim-bit-size-color-base: #DDDDDD;
+    -csim-bit-size-color-border: #BBBBBB;
+
+    /* Slider thumb palette */
+    -csim-thumb-base:    -csim-bit-size-color-base;
+    -csim-thumb-border:  -csim-bit-size-color-border;
+    -csim-thumb-hover:   derive(-csim-thumb-base, 25%);
+    -csim-thumb-pressed: derive(-csim-thumb-base, 50%);
+
+    /* Level Indicator palette */
+    -csim-level-border-base: #aaaaaa;
+    -csim-top-level-border-indicator: #07c;
+    -csim-nested-level-border-indicator: #c22;
+
+    /* Tilted Pane palette */
+    -csim-tilted-pane-base: #f2f2f2;
+    -csim-tilted-pane-open-base: #f9fafb;
+    -csim-tilted-pane-hover: #dddddd;
+    -csim-tilted-pane-title-base: white;
+    -csim-tilted-pane-title-border: #dddddd;
+
+    /* Color Picker Palette */
+    -csim-color-picker-base: #aee;
+    -csim-color-picker-border: #8cc;
+
+    /* The text color of input during edit */
+    -csim-edit-text-color: -csim-top-level-border-indicator;
+}
+
+/* Buttons */
+.button {
+    -fx-background-color: -csim-btn-color;
+    -fx-text-fill: -csim-btn-text-color;
+    -fx-background-radius: 8;
+    -fx-font-size: 14px;
+}
+.button:hover {
+    -csim-btn-color: -csim-btn-color-hover;
+}
+.button:armed {
+    -csim-btn-color: -csim-btn-color-pressed;
+}
+
+.toggle-button {
+    -fx-background-color: -csim-toggle-btn-border-color, -csim-toggle-btn-color;
+    -fx-background-insets: 0, 1;
+    -fx-text-fill: -csim-toggle-btn-text-color;
+}
+.toggle-button:hover {
+    -csim-toggle-btn-color: -csim-toggle-btn-color-hover;
+}
+.toggle-button:selected {
+    -csim-toggle-btn-color: -csim-toggle-btn-color-pressed;
+}
+.toggle-button:hover:selected {
+    -csim-toggle-btn-color: -csim-toggle-btn-color-pressed-hover;
+}
+
+/* Button for creating new components */
+.new-component-btn {
+    -fx-min-height: 48px;
+    -fx-max-width: 200px;
+    -fx-padding: 8 8 8 8;
+    -fx-background-radius: 8;
+}
+
+/* Properties panel */
+
+/* Properties panel: Content background */
+.props-table {
+    -fx-background-color: white;
+}
+
+/* Properties panel: Label column */
+.props-menu-label {
+    -fx-background-color: transparent;
+    -fx-text-fill: black;
+    -fx-min-width: 128;
+    -fx-padding: 8 8 8 16;
+}
+
+/* Properties panel: Value column */
+.props-menu-value {
+    -fx-background-color: transparent;
+    -fx-text-fill: black;
+    -fx-min-width: 250;
+    -fx-padding: 8 8 8 0;
+}
+
+/* Property list buttons */
+.property-list-validator-button {
+    -fx-background-color: -csim-dropdown-btn-color;
+    -fx-text-fill: -csim-dropdown-btn-text-color;
+    -fx-min-width: 36px;
+}
+.property-list-validator-button:hover {
+    -csim-dropdown-btn-color: -csim-dropdown-btn-color-hover;
+}
+.property-list-validator-button:selected {
+    -csim-dropdown-btn-color: -csim-dropdown-btn-color-pressed;
+}
+.property-list-validator-button:hover:selected {
+    -csim-dropdown-btn-color: -csim-dropdown-btn-color-pressed-hover;
+}
+
+.property-list-validator-dropdown {
+    -fx-background-color: -csim-dropdown-btn-color;
+    -fx-background-radius: 8 8 8 8;
+    -fx-border-width: 1 1 1 1;
+    -fx-border-color: -csim-dropdown-btn-color-border;
+    -fx-border-radius: 8 8 8 8;
+}
+
+.button-top-left {
+    -fx-background-radius: 8 0 0 0;
+}
+
+.button-top-right {
+    -fx-background-radius: 0 8 0 0;
+}
+
+.button-bottom-left {
+    -fx-background-radius: 0 0 0 8;
+}
+
+.button-bottom-right {
+    -fx-background-radius: 0 0 8 0;
+}
+
+.button-left {
+    -fx-background-radius: 8 0 0 8;
+}
+
+.button-right {
+    -fx-background-radius: 0 8 8 0;
+}
+
+.button-tab-pane {
+    -fx-background-color: -csim-tab-btn-pane-color-base;
+    -fx-border-color: transparent;
+    -fx-padding: 10;
+}
+
+.new-component-section {
+    -fx-background-color: white;
+    -fx-effect: dropshadow(one-pass-box, rgba(0,0,0,0.05), 6, 0, 0, 2);
+    -fx-padding: 8;
+    -fx-spacing: 4;
+    -fx-transition: all 0.2s ease-in-out;
+
+}
+
+.new-component-section > .title {
+    -fx-background-color: white;
+    -fx-text-fill: -csim-component-text-color;
+    -fx-font-size: 15px;
+    -fx-font-weight: 600;
+    -fx-padding: 10 14;
+}
+
+.new-component-section:expanded > .title {
+    -fx-background-color: -csim-component-expanded-base;
+}
+
+.new-component-section > *.content {
+    -fx-padding: 4 4 0 4;
+    -fx-background-color: -csim-component-expanded-base;
+    -fx-border-color: -csim-component-expanded-base;
+}
+
+.new-component-section > .content {
+    -fx-transition: all 0.3s ease;
+}
+
+.new-component-section > .title > .arrow-button {
+    -fx-background-color: transparent;
+}
+
+.new-component-section > .title > .arrow-button > .arrow {
+    -fx-shape: "M 0 0 L 6 6 L 12 0 Z";
+    -fx-background-color: -csim-component-arrow-base;
+    -fx-focus-color: transparent;
+    -fx-scale-x: 0.8;
+    -fx-scale-y: 0.8;
+}
+
+.text-field {
+    -fx-background-color: -csim-component-text-base;
+    -fx-background-radius: 8;
+    -fx-border-color: transparent;
+    -fx-border-radius: 8;
+    -fx-border-width: 2;
+    -fx-padding: 8 12;
+    -fx-font-size: 14px;
+    -fx-text-fill: -csim-text-field-color;
+    -fx-prompt-text-fill: -csim-text-field-prompt-color;
+    -fx-focus-color: transparent;
+    -fx-faint-focus-color: transparent;
+    -fx-effect: dropshadow(one-pass-box, rgba(0,0,0,0.05), 2, 0, 0, 1);
+    -fx-transition: all 0.3s ease-in-out;
+    -fx-max-width: 224px;
+}
+
+.text-field:focused {
+    -fx-border-color: -csim-edit-text-color;
+}
+
+.global-bit-size {
+    -fx-text-alignment: center;
+    -fx-text-fill: red;
+}
+
+.scale-factor {
+
+}
+
+.toolbar-button {
+    -fx-padding: 4;
+}
+
+/* Style the entire TabPane */
+.tab-pane {
+    -fx-background-color: -csim-tab-pane-color-base;
+    -fx-border-color: -csim-tab-pane-color-border;
+    -fx-border-width: 1;
+    -fx-tab-min-width: 64px;
+}
+
+/* Tab header area */
+.tab-pane > .tab-header-area {
+    -fx-background-color: -csim-tab-header-color-base;
+    -fx-padding: 8px 8px 0 8px;
+    -fx-border-color: -csim-tab-pane-color-border;
+    -fx-border-width: 0 0 1 0;
+}
+
+/* Individual tabs */
+.tab-pane .tab {
+    -fx-background-insets: 0;
+    -fx-padding: 8 16 8 16;
+    -fx-background-color: -csim-tab-pane-color-border;
+    -fx-text-fill: -csim-tab-text-color;
+    -fx-font-size: 14px;
+}
+
+/* Hovered tab */
+.tab-pane .tab:hover {
+    -fx-background-color: -csim-tab-pane-color-hover;
+}
+
+/* Selected tab */
+.tab-pane .tab:selected {
+    -fx-background-color: -csim-tab-pane-color-selected;
+    -fx-text-fill: black;
+    -fx-border-width: 1 1 5 1;
+    -fx-focus-color: transparent;
+    -fx-faint-focus-color: transparent;
+}
+
+.top-level-indicator {
+    -fx-border-color:
+        -csim-level-border-base
+        -csim-level-border-base
+        -csim-top-level-border-indicator
+        -csim-level-border-base;
+}
+
+.nested-state-indicator {
+    -fx-border-color:
+        -csim-level-border-base
+        -csim-level-border-base
+        -csim-nested-level-border-indicator
+        -csim-level-border-base;
+}
+
+/* Content area */
+.tab-pane .tab-content-area {
+}
+
+.tab-pane .tab {
+    -fx-background-radius: 8 8 0 0;
+    -fx-border-radius: 8 8 0 0;
+}
+.tab-pane .tab:selected {
+}
+
+.bit-size-label {
+    -fx-background-color: transparent;
+    -fx-background-radius: 0;
+    -fx-border-color: transparent;
+    -fx-border-radius: 0;
+    -fx-padding: 4;
+}
+
+.bit-size-dropdown {
+    -fx-background-color: transparent;
+    -fx-background-radius: 0;
+    -fx-border-width: 0;
+    -fx-border-color: transparent;
+    -fx-border-radius: 0;
+    -fx-padding: 4;
+}
+
+.bit-size-box {
+    -fx-alignment: center;
+    -fx-background-color: -csim-bit-size-color-base;
+    -fx-background-radius: 8;
+    -fx-border-width: 1;
+    -fx-border-color: -csim-bit-size-color-border;
+    -fx-border-radius: 8;
+    -fx-pref-height: 25;
+    -fx-max-height: 25;
+}
+
+.bit-size-box:hover {
+    -fx-background-color: derive(-csim-bit-size-color-base, 20%);
+}
+
+.bit-size-box:pressed {
+    -fx-border-color: -csim-edit-text-color;
+}
+
+.bit-size-box:focused {
+    -fx-border-color: -csim-edit-text-color;
+}
+
+.bit-size-box.showing-dropdown {
+    -fx-border-color: -csim-edit-text-color;
+}
+
+/* Scale slider thumb */
+.slider .thumb {
+    -fx-background-color: -csim-thumb-border, -csim-thumb-base;
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 8, 7; /* optional rounding */
+}
+
+.slider .thumb:hover {
+    -fx-background-color: -csim-thumb-border, -csim-thumb-hover;
+}
+
+.slider .thumb:pressed {
+    -fx-background-color: -csim-thumb-border, -csim-thumb-pressed;
+}
+
+.accordion {
+    -fx-background-color: transparent;
+    -fx-border-color: transparent;
+    -fx-spacing: 8px; /* space between panes */
+}
+
+/* TitledPane base */
+.titled-pane {
+    -fx-background-color: -csim-tilted-pane-base;
+    -fx-border-color: -csim-tilted-pane-base;
+    -fx-padding: 0;
+}
+
+
+/* Header / Control area */
+.titled-pane > .title {
+    -fx-background-color: white;
+    -fx-padding: 12px 16px;
+    -fx-font-size: 14px;
+    -fx-font-weight: 500;
+    -fx-border-color: -csim-tilted-pane-hover;
+    -fx-border-width: 0 0 2 0;
+}
+
+/* Hover effect */
+.titled-pane > .title:hover {
+    -fx-background-color: -csim-tilted-pane-hover;
+}
+
+/* Prevent movement during accordian animation */
+.titled-pane > .content {
+    -fx-padding: 12px 16px;
+    -fx-background-color: -csim-tilted-pane-open-base;
+    -fx-smooth: false;
+}
+
+/* Open panel */
+.titled-pane:expanded > .content {
+    -fx-background-color: -csim-tilted-pane-open-base;
+    -fx-padding: 12px 16px;
+}
+
+.titled-pane:first-child > .title {
+    -fx-background-radius: 16px 16px 0 0;
+    -fx-border-radius: 16px 16px 0 0;
+}
+.titled-pane:last-child > .title {
+    -fx-background-radius: 0 0 16px 16px;
+}
+
+.color-picker {
+    -fx-background-color: -csim-color-picker-base;
+    -fx-background-radius: 8 8 8 8;
+    -fx-border-width: 1 1 1 1;
+    -fx-border-color: -csim-color-picker-border;
+    -fx-border-radius: 8 8 8 8;
+}


### PR DESCRIPTION
Reintroduces the UI changes introduced by 1.11.x, now in Java. This hopefully curtails the stability regressions caused by switching to Kotlin.

UI changes (same from #18 and #19):
- Added modern CSS styles
- Updated the left panel to use accordion style instead of tab style
- Added top-level/nested-state indicators for tabs
- Tweaked navigation bar

This closes #20 and #21, due to using the Java base from 1.10.